### PR TITLE
Allow building without xcrun

### DIFF
--- a/BaseBin/boomerang/Makefile
+++ b/BaseBin/boomerang/Makefile
@@ -1,8 +1,14 @@
 TARGET = boomerang
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CC = clang
-
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
 LDFLAGS = -L../.build -ljailbreak
 
 sign: $(TARGET)

--- a/BaseBin/dyldhook/Makefile
+++ b/BaseBin/dyldhook/Makefile
@@ -1,6 +1,13 @@
-CC = clang
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CFLAGS = -I../.include -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
+CFLAGS = -I../.include -isysroot $(SDKROOT) -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
 LDFLAGS = -shared -Xlinker -add_split_seg_info
 FILES = $(wildcard src/*.c src/*.S ../libjailbreak/src/jbclient_mach.c)
 FILES_IOS15 = $(wildcard src/generated/ios15/*.c)

--- a/BaseBin/forkfix/Makefile
+++ b/BaseBin/forkfix/Makefile
@@ -1,7 +1,14 @@
 TARGET = forkfix.dylib
-CC = clang
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(SDKROOT) -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
 LDFLAGS = ../systemhook/systemhook.dylib -dynamiclib
 
 sign: $(TARGET)

--- a/BaseBin/jbctl/Makefile
+++ b/BaseBin/jbctl/Makefile
@@ -1,8 +1,14 @@
 TARGET = jbctl
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CC = clang
-
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
 LDFLAGS = -L../.build -ljailbreak -lchoma
 
 sign: $(TARGET)
@@ -12,4 +18,4 @@ $(TARGET): $(wildcard src/*.m)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 clean:
-	@rm -f $(TARGET)
+        @rm -f $(TARGET)

--- a/BaseBin/launchdhook/Makefile
+++ b/BaseBin/launchdhook/Makefile
@@ -1,7 +1,14 @@
 TARGET = launchdhook.dylib
-CC = clang
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath @loader_path/fallback -L../.build -L../_external/lib -ljailbreak -lellekit -lbsm
 
 sign: $(TARGET)

--- a/BaseBin/libfilecom/Makefile
+++ b/BaseBin/libfilecom/Makefile
@@ -1,8 +1,14 @@
 TARGET = libfilecom.dylib
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CC = clang
-
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src -isysroot $(SDKROOT) -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
 
 sign: $(TARGET)
 	@ldid -S $<
@@ -11,4 +17,4 @@ $(TARGET): $(wildcard src/*.m)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
 
 clean:
-	@rm -f $(TARGET)
+        @rm -f $(TARGET)

--- a/BaseBin/libjailbreak/Makefile
+++ b/BaseBin/libjailbreak/Makefile
@@ -4,10 +4,16 @@ TARGET = libjailbreak.dylib
 
 # for debugging
 ADDITIONAL_FLAGS = -g
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CC = clang
-
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
 LDFLAGS = -larchive -lbsm -L../.build -lchoma
 
 sign: $(TARGET)

--- a/BaseBin/systemhook/Makefile
+++ b/BaseBin/systemhook/Makefile
@@ -1,7 +1,14 @@
 TARGET = systemhook.dylib
-CC = clang
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
 LDFLAGS = -dynamiclib
 
 sign: $(TARGET)

--- a/BaseBin/watchdoghook/Makefile
+++ b/BaseBin/watchdoghook/Makefile
@@ -1,7 +1,14 @@
 TARGET = watchdoghook.dylib
-CC = clang
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb/Library/Frameworks -rpath @loader_path/fallback -L../_external/lib -lellekit -framework IOKit
 
 sign: $(TARGET)

--- a/Exploits/oobPCI/Makefile
+++ b/Exploits/oobPCI/Makefile
@@ -1,12 +1,19 @@
 SDK=macosx
 TARGET=arm64-apple-macos12.0
 
-CC=xcrun -sdk $(SDK) clang
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := xcrun -sdk $(SDK) clang
+SDKROOT ?= $(shell xcrun --sdk $(SDK) --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
 WARNINGS=-Wall -Wpedantic -Werror
 NO_WARNINGS=-Wno-gnu-statement-expression -Wno-gnu-zero-variadic-macro-arguments -Wno-gnu-empty-struct -Wno-dollar-in-identifier-extension -Wno-language-extension-token -Wno-zero-length-array
-CFLAGS=-target $(TARGET) -D__arm64__ -D__aarch64__ -D__DARWIN_OPAQUE_ARM_THREAD_STATE64 -nostdlib -O0 $(WARNINGS) $(NO_WARNINGS)
-LDFLAGS=-target $(TARGET) -nostdlib -dead-strip -fpie -lSystem
+CFLAGS=-target $(TARGET) -D__arm64__ -D__aarch64__ -D__DARWIN_OPAQUE_ARM_THREAD_STATE64 -nostdlib -O0 $(WARNINGS) $(NO_WARNINGS) -isysroot $(SDKROOT)
+LDFLAGS=-target $(TARGET) -nostdlib -dead-strip -fpie -lSystem -isysroot $(SDKROOT)
 
 MIG_SOURCES=$(wildcard Sources/*.defs)
 MIG_GENERATED_SOURCES=$(addprefix Sources/generated/,$(patsubst %.defs,%.c,$(notdir $(MIG_SOURCES))))

--- a/Packages/libkrw-provider/Makefile
+++ b/Packages/libkrw-provider/Makefile
@@ -1,7 +1,14 @@
 TARGET = libkrw-dopamine.dylib
-CC = clang
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb/usr/lib -L../../BaseBin/.build -ljailbreak
 
 all: $(TARGET) sign

--- a/Packages/libroot/Makefile
+++ b/Packages/libroot/Makefile
@@ -1,7 +1,14 @@
 TARGET = libroot.dylib
-CC = clang
+XCRUN_EXISTS := $(shell command -v xcrun >/dev/null 2>&1 && echo 1)
+ifeq ($(XCRUN_EXISTS),1)
+CC := $(shell xcrun --sdk iphoneos clang)
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+CC ?= clang
+SDKROOT ?=
+endif
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb
 
 all: $(TARGET) sign

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Rootless arm64e jailbreak for iOS 15.0 - 15.4.1.
 
 Official website / download: https://xina.cypwn.xyz
 
+## Building
+
+The build system will use `xcrun` if available to locate Apple's SDK and toolchain. When `xcrun` is not installed, the Makefiles fall back to invoking `clang` directly and require the `SDKROOT` environment variable to point to an appropriate SDK path.
+
 ### Why Xinam1ne instead of Dopamine?
 
 Honestly, do what you want. Dopamine works fine to some extent. A lot of you ask me what changes with Xinam1ne and I always have to type out the same old stuff, so have a list of what Xinam1ne has that Dopamine doesn't:


### PR DESCRIPTION
## Summary
- Fallback to clang when xcrun is unavailable and allow SDKROOT override across Makefiles
- Document optional xcrun dependency and SDKROOT requirement in README

## Testing
- `make --dry-run` *(fails: No targets specified and no makefile found)*
- `make --dry-run -C Packages/libroot`
- `make --dry-run -C Exploits/oobPCI`


------
https://chatgpt.com/codex/tasks/task_e_689d833cfe28832d8230f9c0f25ba358