### PR TITLE
Add optional libarchive include detection

### DIFF
--- a/BaseBin/libjailbreak/Makefile
+++ b/BaseBin/libjailbreak/Makefile
@@ -7,7 +7,16 @@ ADDITIONAL_FLAGS = -g
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
+# detect libarchive prefix via brew if available, allow override
+BREW_PREFIX := $(shell command -v brew >/dev/null 2>&1 && brew --prefix)
+LIBARCHIVE_PREFIX ?= $(if $(BREW_PREFIX),$(BREW_PREFIX)/opt/libarchive)
+
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) $(ADDITIONAL_FLAGS)
+
+ifneq ($(LIBARCHIVE_PREFIX),)
+CFLAGS += -I$(LIBARCHIVE_PREFIX)/include
+endif
+
 LDFLAGS = -larchive -lbsm -L../.build -lchoma
 
 sign: $(TARGET)


### PR DESCRIPTION
## Summary
- detect Homebrew and set `LIBARCHIVE_PREFIX` if available
- only add libarchive include path when prefix is provided

## Testing
- `make -C BaseBin/libjailbreak` *(fails: xcrun: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d88d24964832d8c3335901b1a23cf