### PR TITLE
Require SDKROOT when xcrun is missing

### DIFF
--- a/BaseBin/boomerang/Makefile
+++ b/BaseBin/boomerang/Makefile
@@ -2,7 +2,15 @@ TARGET = boomerang
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(SYSROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
 LDFLAGS = -L../.build -ljailbreak
 
 sign: $(TARGET)

--- a/BaseBin/dyldhook/Makefile
+++ b/BaseBin/dyldhook/Makefile
@@ -1,6 +1,14 @@
 CC = clang
 
-CFLAGS = -I../.include -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -I../.include -isysroot $(SYSROOT) -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
 LDFLAGS = -shared -Xlinker -add_split_seg_info
 FILES = $(wildcard src/*.c src/*.S ../libjailbreak/src/jbclient_mach.c)
 FILES_IOS15 = $(wildcard src/generated/ios15/*.c)

--- a/BaseBin/forkfix/Makefile
+++ b/BaseBin/forkfix/Makefile
@@ -1,7 +1,15 @@
 TARGET = forkfix.dylib
 CC = clang
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(SYSROOT) -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
 LDFLAGS = ../systemhook/systemhook.dylib -dynamiclib
 
 sign: $(TARGET)

--- a/BaseBin/jbctl/Makefile
+++ b/BaseBin/jbctl/Makefile
@@ -2,7 +2,15 @@ TARGET = jbctl
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(SYSROOT) -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
 LDFLAGS = -L../.build -ljailbreak -lchoma
 
 sign: $(TARGET)

--- a/BaseBin/launchdhook/Makefile
+++ b/BaseBin/launchdhook/Makefile
@@ -1,7 +1,15 @@
 TARGET = launchdhook.dylib
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc -isysroot $(SYSROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath @loader_path/fallback -L../.build -L../_external/lib -ljailbreak -lellekit -lbsm
 
 sign: $(TARGET)

--- a/BaseBin/libfilecom/Makefile
+++ b/BaseBin/libfilecom/Makefile
@@ -2,7 +2,15 @@ TARGET = libfilecom.dylib
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src -isysroot $(SYSROOT) -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
 
 sign: $(TARGET)
 	@ldid -S $<

--- a/BaseBin/libjailbreak/Makefile
+++ b/BaseBin/libjailbreak/Makefile
@@ -7,7 +7,15 @@ ADDITIONAL_FLAGS = -g
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(SYSROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
 LDFLAGS = -larchive -lbsm -L../.build -lchoma
 
 sign: $(TARGET)

--- a/BaseBin/systemhook/Makefile
+++ b/BaseBin/systemhook/Makefile
@@ -1,7 +1,15 @@
 TARGET = systemhook.dylib
 CC = clang
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(SYSROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
 LDFLAGS = -dynamiclib
 
 sign: $(TARGET)

--- a/BaseBin/watchdoghook/Makefile
+++ b/BaseBin/watchdoghook/Makefile
@@ -1,7 +1,15 @@
 TARGET = watchdoghook.dylib
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(SYSROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb/Library/Frameworks -rpath @loader_path/fallback -L../_external/lib -lellekit -framework IOKit
 
 sign: $(TARGET)

--- a/Exploits/oobPCI/Makefile
+++ b/Exploits/oobPCI/Makefile
@@ -1,7 +1,15 @@
 SDK=macosx
 TARGET=arm64-apple-macos12.0
 
+XCRUN := $(shell command -v xcrun 2>/dev/null)
+ifeq ($(XCRUN),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+CC=clang -isysroot $(SDKROOT)
+else
 CC=xcrun -sdk $(SDK) clang
+endif
 
 WARNINGS=-Wall -Wpedantic -Werror
 NO_WARNINGS=-Wno-gnu-statement-expression -Wno-gnu-zero-variadic-macro-arguments -Wno-gnu-empty-struct -Wno-dollar-in-identifier-extension -Wno-language-extension-token -Wno-zero-length-array

--- a/Packages/libkrw-provider/Makefile
+++ b/Packages/libkrw-provider/Makefile
@@ -1,7 +1,15 @@
 TARGET = libkrw-dopamine.dylib
 CC = clang
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(SYSROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb/usr/lib -L../../BaseBin/.build -ljailbreak
 
 all: $(TARGET) sign

--- a/Packages/libroot/Makefile
+++ b/Packages/libroot/Makefile
@@ -1,7 +1,15 @@
 TARGET = libroot.dylib
 CC = clang
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+SYSROOT := $(shell xcrun --sdk iphoneos --show-sdk-path 2>/dev/null)
+ifeq ($(SYSROOT),)
+ifndef SDKROOT
+$(error SDKROOT is required)
+endif
+SYSROOT := $(SDKROOT)
+endif
+
+CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(SYSROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb
 
 all: $(TARGET) sign


### PR DESCRIPTION
## Summary
- Check for xcrun in build Makefiles
- Abort with "SDKROOT is required" when xcrun is absent and SDKROOT unset

## Testing
- `make -C BaseBin/forkfix` *(fails: SDKROOT is required)*
- `SDKROOT=/ make -n -C BaseBin/forkfix`
- `make -C Exploits/oobPCI` *(fails: SDKROOT is required)*
- `SDKROOT=/ make -n -C Exploits/oobPCI`

------
https://chatgpt.com/codex/tasks/task_e_689d88ccdda8832da6a91981aae29ba6