### PR TITLE
Guard Dopamine make step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all:
 	@./BaseBin/pack.sh
 	@xattr -rc Tools >/dev/null 2>&1
 	$(MAKE) -C Exploits/oobPCI
-	$(MAKE) -C Dopamine
+	if [ -f Dopamine/Makefile ]; then $(MAKE) -C Dopamine; fi
 
 %:
 	@echo "No target rule for $@"


### PR DESCRIPTION
## Summary
- avoid top-level build failure by only invoking Dopamine make if its Makefile exists

## Testing
- `make -n`


------
https://chatgpt.com/codex/tasks/task_e_689d88c6aaec832d8fb1f35826401c3f