### PR TITLE
build: allow overriding SDKROOT in Makefiles

### DIFF
--- a/BaseBin/boomerang/Makefile
+++ b/BaseBin/boomerang/Makefile
@@ -1,8 +1,10 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = boomerang
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
 LDFLAGS = -L../.build -ljailbreak
 
 sign: $(TARGET)

--- a/BaseBin/dyldhook/Makefile
+++ b/BaseBin/dyldhook/Makefile
@@ -1,6 +1,8 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 CC = clang
 
-CFLAGS = -I../.include -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
+CFLAGS = -I../.include -isysroot $(SDKROOT) -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
 LDFLAGS = -shared -Xlinker -add_split_seg_info
 FILES = $(wildcard src/*.c src/*.S ../libjailbreak/src/jbclient_mach.c)
 FILES_IOS15 = $(wildcard src/generated/ios15/*.c)

--- a/BaseBin/forkfix/Makefile
+++ b/BaseBin/forkfix/Makefile
@@ -1,7 +1,9 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = forkfix.dylib
 CC = clang
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(SDKROOT) -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
 LDFLAGS = ../systemhook/systemhook.dylib -dynamiclib
 
 sign: $(TARGET)

--- a/BaseBin/idownloadd/Makefile
+++ b/BaseBin/idownloadd/Makefile
@@ -1,3 +1,4 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
 XCODE_PROJECT = src/idownloadd.xcodeproj
 XCODE_SCHEME = idownloadd
 CS_FLAGS = CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO

--- a/BaseBin/jbctl/Makefile
+++ b/BaseBin/jbctl/Makefile
@@ -1,8 +1,10 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = jbctl
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
 LDFLAGS = -L../.build -ljailbreak -lchoma
 
 sign: $(TARGET)

--- a/BaseBin/launchdhook/Makefile
+++ b/BaseBin/launchdhook/Makefile
@@ -1,7 +1,9 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = launchdhook.dylib
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath @loader_path/fallback -L../.build -L../_external/lib -ljailbreak -lellekit -lbsm
 
 sign: $(TARGET)

--- a/BaseBin/libfilecom/Makefile
+++ b/BaseBin/libfilecom/Makefile
@@ -1,8 +1,10 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = libfilecom.dylib
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src -isysroot $(SDKROOT) -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
 
 sign: $(TARGET)
 	@ldid -S $<

--- a/BaseBin/libjailbreak/Makefile
+++ b/BaseBin/libjailbreak/Makefile
@@ -1,3 +1,5 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = libjailbreak.dylib
 
 #ADDITIONAL_FLAGS = -O3
@@ -7,7 +9,7 @@ ADDITIONAL_FLAGS = -g
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
 LDFLAGS = -larchive -lbsm -L../.build -lchoma
 
 sign: $(TARGET)

--- a/BaseBin/rootlesshooks/Makefile
+++ b/BaseBin/rootlesshooks/Makefile
@@ -1,3 +1,4 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
 TARGET := iphone:clang:latest:15.0
 INSTALL_TARGET_PROCESSES = lsd cfprefsd
 FINALPACKAGE = 1

--- a/BaseBin/systemhook/Makefile
+++ b/BaseBin/systemhook/Makefile
@@ -1,7 +1,9 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = systemhook.dylib
 CC = clang
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
 LDFLAGS = -dynamiclib
 
 sign: $(TARGET)

--- a/BaseBin/watchdoghook/Makefile
+++ b/BaseBin/watchdoghook/Makefile
@@ -1,7 +1,9 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = watchdoghook.dylib
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb/Library/Frameworks -rpath @loader_path/fallback -L../_external/lib -lellekit -framework IOKit
 
 sign: $(TARGET)

--- a/Exploits/oobPCI/Makefile
+++ b/Exploits/oobPCI/Makefile
@@ -1,12 +1,14 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
 SDK=macosx
+SDKROOT ?= $(shell xcrun -sdk $(SDK) --show-sdk-path)
 TARGET=arm64-apple-macos12.0
 
-CC=xcrun -sdk $(SDK) clang
+CC=clang
 
 WARNINGS=-Wall -Wpedantic -Werror
 NO_WARNINGS=-Wno-gnu-statement-expression -Wno-gnu-zero-variadic-macro-arguments -Wno-gnu-empty-struct -Wno-dollar-in-identifier-extension -Wno-language-extension-token -Wno-zero-length-array
-CFLAGS=-target $(TARGET) -D__arm64__ -D__aarch64__ -D__DARWIN_OPAQUE_ARM_THREAD_STATE64 -nostdlib -O0 $(WARNINGS) $(NO_WARNINGS)
-LDFLAGS=-target $(TARGET) -nostdlib -dead-strip -fpie -lSystem
+CFLAGS=-target $(TARGET) -isysroot $(SDKROOT) -D__arm64__ -D__aarch64__ -D__DARWIN_OPAQUE_ARM_THREAD_STATE64 -nostdlib -O0 $(WARNINGS) $(NO_WARNINGS)
+LDFLAGS=-target $(TARGET) -isysroot $(SDKROOT) -nostdlib -dead-strip -fpie -lSystem
 
 MIG_SOURCES=$(wildcard Sources/*.defs)
 MIG_GENERATED_SOURCES=$(addprefix Sources/generated/,$(patsubst %.defs,%.c,$(notdir $(MIG_SOURCES))))

--- a/Packages/libkrw-provider/Makefile
+++ b/Packages/libkrw-provider/Makefile
@@ -1,7 +1,9 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = libkrw-dopamine.dylib
 CC = clang
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb/usr/lib -L../../BaseBin/.build -ljailbreak
 
 all: $(TARGET) sign

--- a/Packages/libroot/Makefile
+++ b/Packages/libroot/Makefile
@@ -1,7 +1,9 @@
+# Requires Xcode's `xcrun` to be available or `SDKROOT` to be defined.
+SDKROOT ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 TARGET = libroot.dylib
 CC = clang
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(SDKROOT) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb
 
 all: $(TARGET) sign


### PR DESCRIPTION
## Summary
- allow specifying SDKROOT in BaseBin, package, and exploit Makefiles to avoid relying solely on xcrun

## Testing
- `make -C BaseBin/watchdoghook -n SDKROOT=/`
- `make -C Packages/libkrw-provider -n SDKROOT=/`
- `make -C Exploits/oobPCI -n SDKROOT=/`


------
https://chatgpt.com/codex/tasks/task_e_689d8e268ee0832d91a753b6ad5bf412