### PR TITLE
Guard libjailbreak Makefile for missing tools

### DIFF
--- a/BaseBin/libjailbreak/Makefile
+++ b/BaseBin/libjailbreak/Makefile
@@ -1,3 +1,11 @@
+## SDK and Homebrew paths
+# Set SDK_PATH and BREW_PREFIX manually if `xcrun` or `brew` are unavailable.
+# Example:
+#   make SDK_PATH=/path/to/iphoneos/sdk BREW_PREFIX=/path/to/homebrew
+
+SDK_PATH ?= $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path || echo /path/to/sdk)
+BREW_PREFIX ?= $(shell command -v brew >/dev/null 2>&1 && brew --prefix || echo /usr/local)
+
 TARGET = libjailbreak.dylib
 
 #ADDITIONAL_FLAGS = -O3
@@ -7,7 +15,7 @@ ADDITIONAL_FLAGS = -g
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(SDK_PATH) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(BREW_PREFIX)/opt/libarchive/include $(ADDITIONAL_FLAGS)
 LDFLAGS = -larchive -lbsm -L../.build -lchoma
 
 sign: $(TARGET)


### PR DESCRIPTION
## Summary
- guard xcrun and brew invocations with command -v checks
- allow SDK_PATH and BREW_PREFIX overrides and reference them in CFLAGS
- document how to override paths when tools are absent

## Testing
- `make -C BaseBin/libjailbreak -n`


------
https://chatgpt.com/codex/tasks/task_e_689d8ed3f7b8832d852dfc221c9a2238