### PR TITLE
chore: add BaseBin clean script

### DIFF
--- a/BaseBin/clean.sh
+++ b/BaseBin/clean.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+
+SCRIPT_DIR=$(dirname -- "$0")
+cd "$SCRIPT_DIR"
+
+# Remove generated artifacts
+dirs=".tmp basebin.tar basebin.tc"
+for item in $dirs; do
+    [ -e "$item" ] && rm -rf "$item"
+done
+
+# Clean subdirectories that produce binaries
+for dir in libfilecom libjailbreak jailbreakd idownloadd boomerang jbinit jbctl launchdhook systemhook watchdoghook rootlesshooks forkfix dyldhook; do
+    if [ -d "$dir" ]; then
+        (cd "$dir" && make clean >/dev/null 2>&1 || true)
+    fi
+done
+
+cd - >/dev/null


### PR DESCRIPTION
## Summary
- Add cleanup script to remove BaseBin build artifacts and compiled binaries

## Testing
- `bash -n BaseBin/clean.sh`
- `./BaseBin/clean.sh`


------
https://chatgpt.com/codex/tasks/task_e_689d8f3aef94832d856710a4ef084ae5