### PR TITLE
Handle missing macOS tools in libjailbreak build

### DIFF
--- a/BaseBin/libjailbreak/Makefile
+++ b/BaseBin/libjailbreak/Makefile
@@ -7,8 +7,27 @@ ADDITIONAL_FLAGS = -g
 
 CC = clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
-LDFLAGS = -larchive -lbsm -L../.build -lchoma
+XCRUN := $(shell command -v xcrun 2>/dev/null)
+ifneq ($(XCRUN),)
+    SDK_PATH := $(shell xcrun --sdk iphoneos --show-sdk-path)
+else
+    SDK_PATH ?= $(SDKROOT)
+endif
+
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) $(ADDITIONAL_FLAGS)
+CFLAGS += -isysroot $(SDK_PATH)
+LDFLAGS = -lbsm -L../.build -lchoma
+
+ifneq ($(shell pkg-config --exists libarchive && echo yes 2>/dev/null),)
+    CFLAGS += $(shell pkg-config --cflags libarchive)
+    LDFLAGS += $(shell pkg-config --libs libarchive)
+else ifneq ($(shell command -v brew 2>/dev/null),)
+    CFLAGS += -I$(shell brew --prefix)/opt/libarchive/include
+    LDFLAGS += -L$(shell brew --prefix)/opt/libarchive/lib -larchive
+else
+    CFLAGS += -I/usr/include
+    LDFLAGS += -L/usr/lib -larchive
+endif
 
 sign: $(TARGET)
 	@ldid -S $<


### PR DESCRIPTION
## Summary
- Detect `xcrun` before using it and fall back to `$SDKROOT` when unavailable
- Use `pkg-config` or fallback include/lib paths for `libarchive`

## Testing
- `make -C BaseBin/libjailbreak` *(fails: clang: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689d91dc8864832dbe44af6f25cea331