### PR TITLE
feat: allow overriding xcrun in ios sdk

### DIFF
--- a/build/ios_sdk.mk
+++ b/build/ios_sdk.mk
@@ -1,0 +1,3 @@
+XCRUN ?= xcrun
+
+SDKROOT := $(shell $(XCRUN) --sdk iphoneos --show-sdk-path)


### PR DESCRIPTION
## Summary
- add XCRUN variable to ios SDK make snippet so callers can override xcrun

## Testing
- `make -n -f /tmp/test.mk XCRUN=echo test`


------
https://chatgpt.com/codex/tasks/task_e_689d929a0b5c832d9862e97f578bd8bc