### PR TITLE
Handle TrollStore delete bootstrap errors

### DIFF
--- a/Dopamine/Jailbreak/DOEnvironmentManager.h
+++ b/Dopamine/Jailbreak/DOEnvironmentManager.h
@@ -64,6 +64,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSError *)prepareBootstrap;
 - (NSError *)finalizeBootstrap;
+/**
+ * Attempts to delete the existing bootstrap.
+ *
+ * @return An NSError describing the failure when the TrollStore action
+ *         fails or the bootstrap could not be deleted, otherwise nil.
+ */
 - (NSError *)deleteBootstrap;
 - (NSError *)reinstallPackageManagers;
 @end

--- a/Dopamine/Jailbreak/DOEnvironmentManager.m
+++ b/Dopamine/Jailbreak/DOEnvironmentManager.m
@@ -644,7 +644,9 @@ int reboot3(uint64_t flags, ...);
     if (![self isJailbroken] && getuid() != 0) {
         int r = [self runTrollStoreAction:@"delete-bootstrap"];
         if (r != 0) {
-            // TODO: maybe handle error
+            NSString *errorMessage = [NSString stringWithFormat:@"Failed to delete bootstrap (rc=%d)", r];
+            [[DOUIManager sharedInstance] sendLog:errorMessage debug:NO];
+            return [NSError errorWithDomain:@"Dopamine" code:r userInfo:@{NSLocalizedDescriptionKey : errorMessage}];
         }
         return nil;
     }


### PR DESCRIPTION
## Summary
- add error handling for TrollStore delete-bootstrap failures
- document deleteBootstrap error behavior

## Testing
- `make test` *(fails: No target rule for test)*

------
https://chatgpt.com/codex/tasks/task_e_689d94aafccc832db056db1536cbb10a