### PR TITLE
Add bounds validation to buffered_stream_trim

### DIFF
--- a/BaseBin/ChOma/BufferedStream.c
+++ b/BaseBin/ChOma/BufferedStream.c
@@ -67,11 +67,21 @@ static uint8_t *buffered_stream_get_raw_pointer(MemoryStream *stream)
     return &context->buffer[context->subBufferStart];
 }
 
+/*
+ * Trims the current sub-buffer by removing bytes at the beginning and end.
+ *
+ * Returns 0 on success or -1 if the trim sizes exceed the current
+ * sub-buffer size. On failure the buffer remains unchanged.
+ */
 static int buffered_stream_trim(MemoryStream *stream, size_t trimAtStart, size_t trimAtEnd)
 {
     BufferedStreamContext *context = stream->context;
 
-    // TODO: bound checks
+    if (trimAtStart > context->subBufferSize || trimAtEnd > context->subBufferSize ||
+        (trimAtStart + trimAtEnd) > context->subBufferSize) {
+        return -1;
+    }
+
     context->subBufferStart += trimAtStart;
     context->subBufferSize -= (trimAtEnd + trimAtStart);
 

--- a/BaseBin/ChOma/MemoryStream.h
+++ b/BaseBin/ChOma/MemoryStream.h
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #define MEMORY_STREAM_FLAG_OWNS_DATA (1 << 0)
 #define MEMORY_STREAM_FLAG_MUTABLE (1 << 1)


### PR DESCRIPTION
## Summary
- add validation checks to `buffered_stream_trim` to prevent over-trimming and document new error case

## Testing
- `gcc -c BaseBin/ChOma/BufferedStream.c -IBaseBin/ChOma` *(fails: unknown type name `uint32_t`)*

------
https://chatgpt.com/codex/tasks/task_e_689d94a4be10832da5c802e1d3e08ae3