### PR TITLE
Handle allocation failure in buffered stream expansion

### DIFF
--- a/BaseBin/ChOma/BufferedStream.c
+++ b/BaseBin/ChOma/BufferedStream.c
@@ -47,7 +47,8 @@ static int buffered_stream_write(MemoryStream *stream, uint64_t offset, size_t s
     }
 
     if (needsExpand) {
-        buffered_stream_expand(stream, 0, (offset + size) - context->subBufferSize);
+        int r = buffered_stream_expand(stream, 0, (offset + size) - context->subBufferSize);
+        if (r != 0) return r;
     }
 
     memcpy(context->buffer + context->subBufferStart + offset, inBuf, size);
@@ -84,6 +85,9 @@ static int buffered_stream_expand(MemoryStream *stream, size_t expandAtStart, si
 
     size_t newSize = context->subBufferSize + expandAtStart + expandAtEnd;
     uint8_t *newBuffer = malloc(newSize);
+    if (!newBuffer) {
+        return -1;
+    }
     memset(newBuffer, 0, newSize);
     memcpy(&newBuffer[expandAtStart], &context->buffer[context->subBufferStart], context->subBufferSize);
     if (stream->flags & MEMORY_STREAM_FLAG_OWNS_DATA) {


### PR DESCRIPTION
## Summary
- guard against `malloc` failure in `buffered_stream_expand`
- propagate expansion errors to `buffered_stream_write`

## Testing
- `make` *(fails: xcrun: No such file or directory; clang: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d94a72c34832dbe5c214e61801b8d