### PR TITLE
Validate load command size before allocation in MachO parser

### DIFF
--- a/BaseBin/ChOma/MachO.c
+++ b/BaseBin/ChOma/MachO.c
@@ -203,23 +203,41 @@ int macho_enumerate_load_commands(MachO *macho, void (^enumeratorBlock)(struct l
     }
 
     // First load command starts after mach header
-    uint64_t offset = macho_get_mach_header_size(macho);
+    uint64_t headerSize = macho_get_mach_header_size(macho);
+    uint64_t headerEnd = headerSize + macho->machHeader.sizeofcmds;
+    uint64_t offset = headerSize;
 
     for (int j = 0; j < macho->machHeader.ncmds; j++) {
         struct load_command loadCommand;
         if (macho_read_at_offset(macho, offset, sizeof(loadCommand), &loadCommand) != 0) continue;
         LOAD_COMMAND_APPLY_BYTE_ORDER(&loadCommand, LITTLE_TO_HOST_APPLIER);
 
+        uint64_t remaining = headerEnd > offset ? headerEnd - offset : 0;
+        if (loadCommand.cmdsize < sizeof(struct load_command) || loadCommand.cmdsize > remaining) {
+            printf("Error: invalid load command size (%u).\n", loadCommand.cmdsize);
+            offset += loadCommand.cmdsize;
+            continue;
+        }
+
         if (strcmp(load_command_to_string(loadCommand.cmd), "LC_UNKNOWN") == 0)
         {
             printf("Ignoring unknown command: 0x%x.\n", loadCommand.cmd);
         }
         else {
-            // TODO: Check if cmdsize matches expected size for cmd
-            uint8_t cmd[loadCommand.cmdsize];
-            if (macho_read_at_offset(macho, offset, loadCommand.cmdsize, cmd) != 0) continue;
+            uint8_t *cmd = malloc(loadCommand.cmdsize);
+            if (!cmd) {
+                printf("Error: failed to allocate %u bytes for load command.\n", loadCommand.cmdsize);
+                offset += loadCommand.cmdsize;
+                continue;
+            }
+            if (macho_read_at_offset(macho, offset, loadCommand.cmdsize, cmd) != 0) {
+                free(cmd);
+                offset += loadCommand.cmdsize;
+                continue;
+            }
             bool stop = false;
             enumeratorBlock(loadCommand, offset, (void *)cmd, &stop);
+            free(cmd);
             if (stop) break;
         }
         offset += loadCommand.cmdsize;


### PR DESCRIPTION
## Summary
- verify load command size fits within Mach-O header bounds before processing
- allocate load command buffer dynamically and free after use
- log an error and skip commands when validation or allocation fails

## Testing
- `gcc -c BaseBin/ChOma/MachO.c -IBaseBin/ChOma` *(fails: libkern/OSByteOrder.h: No such file or directory)*
- `make` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689d94a909d0832db4b726bf3be58853