### PR TITLE
Allow overriding compiler and SDK path in Makefiles

### DIFF
--- a/BaseBin/boomerang/Makefile
+++ b/BaseBin/boomerang/Makefile
@@ -1,9 +1,17 @@
 TARGET = boomerang
 
-CC = clang
+CC ?= clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
 LDFLAGS = -L../.build -ljailbreak
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 sign: $(TARGET)
 	@ldid -Sentitlements.plist $<

--- a/BaseBin/dyldhook/Makefile
+++ b/BaseBin/dyldhook/Makefile
@@ -1,10 +1,18 @@
-CC = clang
+CC ?= clang
 
-CFLAGS = -I../.include -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
+CFLAGS = -I../.include -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
 LDFLAGS = -shared -Xlinker -add_split_seg_info
 FILES = $(wildcard src/*.c src/*.S ../libjailbreak/src/jbclient_mach.c)
 FILES_IOS15 = $(wildcard src/generated/ios15/*.c)
 FILES_IOS16 = $(wildcard src/generated/ios16/*.c)
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 all: dyldhook_merge.arm64e.dylib dyldhook_merge.arm64e.iOS15.dylib dyldhook_merge.arm64.dylib dyldhook_merge.arm64.iOS15.dylib
 

--- a/BaseBin/forkfix/Makefile
+++ b/BaseBin/forkfix/Makefile
@@ -1,8 +1,16 @@
 TARGET = forkfix.dylib
-CC = clang
+CC ?= clang
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
 LDFLAGS = ../systemhook/systemhook.dylib -dynamiclib
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 sign: $(TARGET)
 	@ldid -S $^

--- a/BaseBin/jbctl/Makefile
+++ b/BaseBin/jbctl/Makefile
@@ -1,9 +1,17 @@
 TARGET = jbctl
 
-CC = clang
+CC ?= clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
 LDFLAGS = -L../.build -ljailbreak -lchoma
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 sign: $(TARGET)
 	@ldid -Sentitlements.plist $<

--- a/BaseBin/launchdhook/Makefile
+++ b/BaseBin/launchdhook/Makefile
@@ -1,8 +1,16 @@
 TARGET = launchdhook.dylib
-CC = clang
+CC ?= clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath @loader_path/fallback -L../.build -L../_external/lib -ljailbreak -lellekit -lbsm
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 sign: $(TARGET)
 	@ldid -S $^

--- a/BaseBin/libfilecom/Makefile
+++ b/BaseBin/libfilecom/Makefile
@@ -1,8 +1,16 @@
 TARGET = libfilecom.dylib
 
-CC = clang
+CC ?= clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 sign: $(TARGET)
 	@ldid -S $<

--- a/BaseBin/libjailbreak/Makefile
+++ b/BaseBin/libjailbreak/Makefile
@@ -5,10 +5,18 @@ TARGET = libjailbreak.dylib
 # for debugging
 ADDITIONAL_FLAGS = -g
 
-CC = clang
+CC ?= clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
 LDFLAGS = -larchive -lbsm -L../.build -lchoma
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 sign: $(TARGET)
 	@ldid -S $<

--- a/BaseBin/systemhook/Makefile
+++ b/BaseBin/systemhook/Makefile
@@ -1,8 +1,16 @@
 TARGET = systemhook.dylib
-CC = clang
+CC ?= clang
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
 LDFLAGS = -dynamiclib
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 sign: $(TARGET)
 	@ldid -S $^

--- a/BaseBin/watchdoghook/Makefile
+++ b/BaseBin/watchdoghook/Makefile
@@ -1,8 +1,16 @@
 TARGET = watchdoghook.dylib
-CC = clang
+CC ?= clang
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb/Library/Frameworks -rpath @loader_path/fallback -L../_external/lib -lellekit -framework IOKit
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 sign: $(TARGET)
 	@ldid -S $^

--- a/Exploits/oobPCI/Makefile
+++ b/Exploits/oobPCI/Makefile
@@ -1,12 +1,21 @@
 SDK=macosx
 TARGET=arm64-apple-macos12.0
 
-CC=xcrun -sdk $(SDK) clang
+CC ?= clang
 
 WARNINGS=-Wall -Wpedantic -Werror
 NO_WARNINGS=-Wno-gnu-statement-expression -Wno-gnu-zero-variadic-macro-arguments -Wno-gnu-empty-struct -Wno-dollar-in-identifier-extension -Wno-language-extension-token -Wno-zero-length-array
 CFLAGS=-target $(TARGET) -D__arm64__ -D__aarch64__ -D__DARWIN_OPAQUE_ARM_THREAD_STATE64 -nostdlib -O0 $(WARNINGS) $(NO_WARNINGS)
 LDFLAGS=-target $(TARGET) -nostdlib -dead-strip -fpie -lSystem
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk $(SDK) --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(MACOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+LDFLAGS += -isysroot $(SDK_PATH)
+endif
 
 MIG_SOURCES=$(wildcard Sources/*.defs)
 MIG_GENERATED_SOURCES=$(addprefix Sources/generated/,$(patsubst %.defs,%.c,$(notdir $(MIG_SOURCES))))

--- a/Packages/libkrw-provider/Makefile
+++ b/Packages/libkrw-provider/Makefile
@@ -1,8 +1,16 @@
 TARGET = libkrw-dopamine.dylib
-CC = clang
+CC ?= clang
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -I../../BaseBin/.include -Isrc -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb/usr/lib -L../../BaseBin/.build -ljailbreak
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 all: $(TARGET) sign
 

--- a/Packages/libroot/Makefile
+++ b/Packages/libroot/Makefile
@@ -1,8 +1,16 @@
 TARGET = libroot.dylib
-CC = clang
+CC ?= clang
 
-CFLAGS = -I../../BaseBin/.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -I../../BaseBin/.include -Isrc -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb
+
+SDK_PATH := $(shell command -v xcrun >/dev/null 2>&1 && xcrun --sdk iphoneos --show-sdk-path)
+ifeq ($(SDK_PATH),)
+SDK_PATH := $(IOS_SDK_PATH)
+endif
+ifneq ($(SDK_PATH),)
+CFLAGS += -isysroot $(SDK_PATH)
+endif
 
 all: $(TARGET) sign
 

--- a/README.md
+++ b/README.md
@@ -16,3 +16,14 @@ Honestly, do what you want. Dopamine works fine to some extent. A lot of you ask
 That's all folks!
 
 <img src="https://media.tenor.com/xvo8-YQ78P0AAAAC/porky-pig.gif)https://media.tenor.com/xvo8-YQ78P0AAAAC/porky-pig.gif" width="320" />
+
+## Building
+
+The build system defaults to `clang`. To use a different toolchain, override the `CC` variable:
+
+```
+make CC=gcc    # GNU toolchain
+make CC=cl     # MSVC toolchain
+```
+
+If `xcrun` is unavailable, set `IOS_SDK_PATH` (or `MACOS_SDK_PATH` for macOS targets) to the SDK location or rely on system headers.


### PR DESCRIPTION
## Summary
- Allow CC override in all Makefiles with `CC ?= clang`
- Use optional SDK detection and environment variable fallback for `-isysroot`
- Document `make CC=gcc` or `make CC=cl` in README

## Testing
- `make -C BaseBin/jbctl CC=gcc -n`
- `make -C BaseBin/jbctl CC=cl -n`


------
https://chatgpt.com/codex/tasks/task_e_689d9860bb78832db332494a6aaa11b8