### PR TITLE
Define DOEnvironmentErrorDomain constant

### DIFF
--- a/Dopamine/Jailbreak/DOEnvironmentManager.h
+++ b/Dopamine/Jailbreak/DOEnvironmentManager.h
@@ -10,6 +10,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+FOUNDATION_EXPORT NSString *const DOEnvironmentErrorDomain;
+
 @interface DOEnvironmentManager : NSObject
 {
     DOBootstrapper *_bootstrapper;

--- a/Dopamine/Jailbreak/DOEnvironmentManager.m
+++ b/Dopamine/Jailbreak/DOEnvironmentManager.m
@@ -23,6 +23,8 @@
 #import "DOExploitManager.h"
 #import "NSData+Hex.h"
 
+NSString *const DOEnvironmentErrorDomain = @"DOEnvironmentErrorDomain";
+
 int reboot3(uint64_t flags, ...);
 
 @implementation DOEnvironmentManager
@@ -390,7 +392,7 @@ int reboot3(uint64_t flags, ...);
         [self rebootUserspace];
         return nil;
     }
-    return [NSError errorWithDomain:@"Dopamine" code:result userInfo:nil];
+    return [NSError errorWithDomain:DOEnvironmentErrorDomain code:result userInfo:nil];
 }
 
 - (void)updateJailbreakFromTIPA:(NSString *)tipaPath


### PR DESCRIPTION
## Summary
- define `DOEnvironmentErrorDomain` constant
- use `DOEnvironmentErrorDomain` for NSError domain
- expose constant for external modules

## Testing
- `make test` *(fails: No target rule for test)*
- `make` *(fails: xcrun: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d98d65be0832dab966f2310b4223d