### PR TITLE
Make deleteBootstrap return nullable error

### DIFF
--- a/Dopamine/Jailbreak/DOEnvironmentManager.h
+++ b/Dopamine/Jailbreak/DOEnvironmentManager.h
@@ -64,7 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSError *)prepareBootstrap;
 - (NSError *)finalizeBootstrap;
-- (NSError *)deleteBootstrap;
+- (NSError * _Nullable)deleteBootstrap;
 - (NSError *)reinstallPackageManagers;
 @end
 

--- a/Dopamine/Jailbreak/DOEnvironmentManager.m
+++ b/Dopamine/Jailbreak/DOEnvironmentManager.m
@@ -639,7 +639,7 @@ int reboot3(uint64_t flags, ...);
     return [_bootstrapper finalizeBootstrap];
 }
 
-- (NSError *)deleteBootstrap
+- (NSError * _Nullable)deleteBootstrap
 {
     if (![self isJailbroken] && getuid() != 0) {
         int r = [self runTrollStoreAction:@"delete-bootstrap"];


### PR DESCRIPTION
## Summary
- Mark deleteBootstrap method as returning a nullable NSError
- Update DOEnvironmentManager implementation to match

## Testing
- `make` *(fails: ./BaseBin/pack.sh: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689d98d922f0832d9e80d8d61db66a8c