### PR TITLE
Localize bootstrap deletion failure message

### DIFF
--- a/Dopamine/Jailbreak/DOEnvironmentManager.m
+++ b/Dopamine/Jailbreak/DOEnvironmentManager.m
@@ -644,7 +644,7 @@ int reboot3(uint64_t flags, ...);
     if (![self isJailbroken] && getuid() != 0) {
         int r = [self runTrollStoreAction:@"delete-bootstrap"];
         if (r != 0) {
-            // TODO: maybe handle error
+            [[DOUIManager sharedInstance] sendLog:[NSString stringWithFormat:DOLocalizedString(@"Delete_Bootstrap_Failed"), r] debug:NO];
         }
         return nil;
     }

--- a/Dopamine/ar.lproj/Localizable.strings
+++ b/Dopamine/ar.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 "Bypassing PAC (%@)" = "تجاوز PAC (%@)";
 "Bypassing PPL (%@)" = "تجاوز PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "اختر مدير الحزمة";
 "Select_Package_Managers_Install_Message" = "إذا كنت محتارًا في الاختيار، فاختر Sileo";

--- a/Dopamine/da.lproj/Localizable.strings
+++ b/Dopamine/da.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Vælg Pakkehåndteringsprogram(mer)";
 "Select_Package_Managers_Install_Message" = "If you are unsure which one to select, select Sileo";

--- a/Dopamine/de.lproj/Localizable.strings
+++ b/Dopamine/de.lproj/Localizable.strings
@@ -110,6 +110,8 @@
 "Bypassing PAC (%@)" = "Umgehe PAC (%@)";
 "Bypassing PPL (%@)" = "Umgehe PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Paket Manager auswählen";
 "Select_Package_Managers_Install_Message" = "Bei Unklarheiten, wähle Sileo aus";

--- a/Dopamine/el.lproj/Localizable.strings
+++ b/Dopamine/el.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Επιλογή εφαρμογής/ών διαχείρισης πακέτων";
 "Select_Package_Managers_Install_Message" = "Αν δεν είστε σίγουροι, επιλέξτε το Sileo";

--- a/Dopamine/en.lproj/Localizable.strings
+++ b/Dopamine/en.lproj/Localizable.strings
@@ -110,6 +110,8 @@
 "Bypassing PAC (%@)" = "Bypassing PAC (%@)";
 "Bypassing PPL (%@)" = "Bypassing PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Select Package Manager(s)";
 "Select_Package_Managers_Install_Message" = "If you are unsure which one to select, select Sileo";

--- a/Dopamine/es.lproj/Localizable.strings
+++ b/Dopamine/es.lproj/Localizable.strings
@@ -109,6 +109,8 @@
 "Bypassing PAC (%@)" = "Saltando PAC (%@)";
 "Bypassing PPL (%@)" = "Saltando PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Seleccione gestor(es) de paquetes";
 "Select_Package_Managers_Install_Message" = "Si no está seguro de cuál seleccionar, seleccione Sileo";

--- a/Dopamine/fil.lproj/Localizable.strings
+++ b/Dopamine/fil.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 "Bypassing PAC (%@)" = "Bina-Bypass ang PAC (%@)";
 "Bypassing PPL (%@)" = "Bina-Bypass ang PPL";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Pumili ng mga Package Manager(s)";
 "Select_Package_Managers_Install_Message" = "Kung hindi ka sigurado kung alin ang pipiliin, piliin ang Sileo";

--- a/Dopamine/fr.lproj/Localizable.strings
+++ b/Dopamine/fr.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 "Bypassing PAC (%@)" = "Contournement des PAC (%@)";
 "Bypassing PPL (%@)" = "Contournement du PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Gestionnaires de paquets";
 "Select_Package_Managers_Install_Message" = "Selectionnez les gestionnaires de paquets à installer, si vous n'êtes pas sûr de votre choix, sélectionnez Sileo";

--- a/Dopamine/it.lproj/Localizable.strings
+++ b/Dopamine/it.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Seleziona i Package Manager";
 "Select_Package_Managers_Install_Message" = "Se non sei sicuro/a di quale scegliere, scegli Sileo";

--- a/Dopamine/ja.lproj/Localizable.strings
+++ b/Dopamine/ja.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 "Bypassing PAC (%@)" = "Bypassing PAC (%@)";
 "Bypassing PPL (%@)" = "Bypassing PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "パッケージマネージャーを選択";
 "Select_Package_Managers_Install_Message" = "どちらを選択するか迷った場合は、Sileoを選択してください";

--- a/Dopamine/kk.lproj/Localizable.strings
+++ b/Dopamine/kk.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Пакет менеджерін таңдаңыз";
 "Select_Package_Managers_Install_Message" = "If you are unsure which one to select, select Sileo";

--- a/Dopamine/ko.lproj/Localizable.strings
+++ b/Dopamine/ko.lproj/Localizable.strings
@@ -109,6 +109,8 @@
 "Bypassing PAC (%@)" = "PAC 우회 중 (%@)";
 "Bypassing PPL (%@)" = "PPL 우회 중 (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "패키지 매니저 선택";
 "Select_Package_Managers_Install_Message" = "어떤 것을 선택할지 모르겠다면 Sileo를 선택하세요.";

--- a/Dopamine/nl.lproj/Localizable.strings
+++ b/Dopamine/nl.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Selecteer Package Manager(s)";
 "Select_Package_Managers_Install_Message" = "Als u niet zeker weet welke u moet selecteren, selecteer dan Sileo";

--- a/Dopamine/pl.lproj/Localizable.strings
+++ b/Dopamine/pl.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Wybierz menedżer(y) pakietów";
 "Select_Package_Managers_Install_Message" = "Jeżeli nie jesteś pewien który wybrać, wybierz Sileo";

--- a/Dopamine/pt-BR.lproj/Localizable.strings
+++ b/Dopamine/pt-BR.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Escolha o(s) Gerenciador(es) de Pacotes";
 "Select_Package_Managers_Install_Message" = "Se estiver em dúvida, selecione o Sileo";

--- a/Dopamine/ru.lproj/Localizable.strings
+++ b/Dopamine/ru.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 "Bypassing PAC (%@)" = "Обход PAC (%@)";
 "Bypassing PPL (%@)" = "Обход PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Выберите менеджер(ы) пакетов";
 "Select_Package_Managers_Install_Message" = "Если вы не знаете, какой из них выбрать, выберите Sileo";

--- a/Dopamine/sv.lproj/Localizable.strings
+++ b/Dopamine/sv.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Välj pakethanterare";
 "Select_Package_Managers_Install_Message" = "If you are unsure which one to select, select Sileo";

--- a/Dopamine/th.lproj/Localizable.strings
+++ b/Dopamine/th.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 "Bypassing PAC (%@)" = "Bypassing PAC (%@)";
 "Bypassing PPL (%@)" = "Bypassing PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "เลือก Package Manager(s) ที่ต้องการ";
 "Select_Package_Managers_Install_Message" = "ถ้าไม่แน่ใจว่าจะเลือกอันไหน ให้เลือก Sileo";

--- a/Dopamine/tr.lproj/Localizable.strings
+++ b/Dopamine/tr.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Paket Yöneticisi Seçin";
 "Select_Package_Managers_Install_Message" = "If you are unsure which one to select, select Sileo";

--- a/Dopamine/uk.lproj/Localizable.strings
+++ b/Dopamine/uk.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Вибрати менеджер(и) пакунків";
 "Select_Package_Managers_Install_Message" = "If you are unsure which one to select, select Sileo";

--- a/Dopamine/ur.lproj/Localizable.strings
+++ b/Dopamine/ur.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "پیکیج مینیجرز کو منتخب کریں";
 "Select_Package_Managers_Install_Message" = "If you are unsure which one to select, select Sileo";

--- a/Dopamine/vi.lproj/Localizable.strings
+++ b/Dopamine/vi.lproj/Localizable.strings
@@ -109,6 +109,8 @@
 "Bypassing PAC (%@)" = "Kh.thác lỗ hổng PAC (%@)";
 "Bypassing PPL (%@)" = "Kh.thác lỗ hổng PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "Chọn trình quản lý gói";
 "Select_Package_Managers_Install_Message" = "Nếu bạn không biết nên nhấn vào lựa chọn nào, hãy chọn Sileo (sẽ không bao giờ có Cydia cho bạn chọn)";

--- a/Dopamine/zh-CN.lproj/Localizable.strings
+++ b/Dopamine/zh-CN.lproj/Localizable.strings
@@ -109,6 +109,8 @@
 "Bypassing PAC (%@)" = "正在绕过 PAC (%@)";
 "Bypassing PPL (%@)" = "正在绕过 PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "请选择包管理器";
 "Select_Package_Managers_Install_Message" = "如果你不确定选择哪一个比较好，请选择 Sileo";

--- a/Dopamine/zh-HK.lproj/Localizable.strings
+++ b/Dopamine/zh-HK.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 /*Bypassing PAC (%@)*/
 /*Bypassing PPL (%@)*/
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "選定包管理器（越獄商店）";
 "Select_Package_Managers_Install_Message" = "若不確定如何選擇，請使用 Sileo";

--- a/Dopamine/zh-Hans.lproj/Localizable.strings
+++ b/Dopamine/zh-Hans.lproj/Localizable.strings
@@ -109,6 +109,8 @@
 "Bypassing PAC (%@)" = "正在绕过 PAC (%@)";
 "Bypassing PPL (%@)" = "正在绕过 PPL (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "请选择包管理器";
 "Select_Package_Managers_Install_Message" = "如果你不确定选择哪一个比较好，请选择 Sileo";

--- a/Dopamine/zh-TW.lproj/Localizable.strings
+++ b/Dopamine/zh-TW.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 "Bypassing PAC (%@)" = "正在繞過 PAC 防護 (%@)";
 "Bypassing PPL (%@)" = "正在繞過 PPL 防護 (%@)";
 
+"Delete_Bootstrap_Failed" = "Failed to delete bootstrap (rc=%d)";
+
 // Package Manager selection
 "Status_Title_Select_Package_Managers" = "選擇套件管理器";
 "Select_Package_Managers_Install_Message" = "如果您不確定要選哪個，請選擇 Sileo";


### PR DESCRIPTION
## Summary
- Localize bootstrap deletion failure log message
- Add `Delete_Bootstrap_Failed` translations to all `Localizable.strings`

## Testing
- `make` *(fails: Permission denied: ./BaseBin/pack.sh)*

------
https://chatgpt.com/codex/tasks/task_e_689d98d7f9cc832d9895518b296f107d