### PR TITLE
make: support cross-compiling with configurable toolchain

### DIFF
--- a/BaseBin/boomerang/Makefile
+++ b/BaseBin/boomerang/Makefile
@@ -1,8 +1,9 @@
 TARGET = boomerang
 
-CC = clang
+CC = $(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src --sysroot $(SDK_PATH) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -O2
 LDFLAGS = -L../.build -ljailbreak
 
 sign: $(TARGET)

--- a/BaseBin/dyldhook/Makefile
+++ b/BaseBin/dyldhook/Makefile
@@ -1,6 +1,7 @@
-CC = clang
+CC = $(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-CFLAGS = -I../.include -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
+CFLAGS = -I../.include --sysroot $(SDK_PATH) -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fno-stack-check -D_FORTIFY_SOURCE=0
 LDFLAGS = -shared -Xlinker -add_split_seg_info
 FILES = $(wildcard src/*.c src/*.S ../libjailbreak/src/jbclient_mach.c)
 FILES_IOS15 = $(wildcard src/generated/ios15/*.c)

--- a/BaseBin/forkfix/Makefile
+++ b/BaseBin/forkfix/Makefile
@@ -1,7 +1,8 @@
 TARGET = forkfix.dylib
-CC = clang
+CC = $(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src --sysroot $(SDK_PATH) -arch arm64e -Wno-deprecated-declarations -miphoneos-version-min=15.0 -O2
 LDFLAGS = ../systemhook/systemhook.dylib -dynamiclib
 
 sign: $(TARGET)

--- a/BaseBin/jbctl/Makefile
+++ b/BaseBin/jbctl/Makefile
@@ -1,8 +1,9 @@
 TARGET = jbctl
 
-CC = clang
+CC = $(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src --sysroot $(SDK_PATH) -arch arm64 -arch arm64e -Wno-availability -miphoneos-version-min=15.0 -fobjc-arc
 LDFLAGS = -L../.build -ljailbreak -lchoma
 
 sign: $(TARGET)

--- a/BaseBin/launchdhook/Makefile
+++ b/BaseBin/launchdhook/Makefile
@@ -1,7 +1,8 @@
 TARGET = launchdhook.dylib
-CC = clang
+CC = $(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -Isrc --sysroot $(SDK_PATH) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -Wno-deprecated-declarations -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath @loader_path/fallback -L../.build -L../_external/lib -ljailbreak -lellekit -lbsm
 
 sign: $(TARGET)

--- a/BaseBin/libfilecom/Makefile
+++ b/BaseBin/libfilecom/Makefile
@@ -1,8 +1,9 @@
 TARGET = libfilecom.dylib
 
-CC = clang
+CC = $(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -I../_shared -I./src --sysroot $(SDK_PATH) -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -Wno-nullability-completeness-on-arrays -dynamiclib -install_name /var/jb/basebin/$(TARGET) -O2
 
 sign: $(TARGET)
 	@ldid -S $<

--- a/BaseBin/libjailbreak/Makefile
+++ b/BaseBin/libjailbreak/Makefile
@@ -5,9 +5,10 @@ TARGET = libjailbreak.dylib
 # for debugging
 ADDITIONAL_FLAGS = -g
 
-CC = clang
+CC = $(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -framework IOKit -framework IOSurface -I../.include -I../_external/modules/litehook/src --sysroot $(SDK_PATH) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -dynamiclib -install_name @loader_path/$(TARGET) -I$(shell brew --prefix)/opt/libarchive/include $(ADDITIONAL_FLAGS)
 LDFLAGS = -larchive -lbsm -L../.build -lchoma
 
 sign: $(TARGET)

--- a/BaseBin/systemhook/Makefile
+++ b/BaseBin/systemhook/Makefile
@@ -1,7 +1,8 @@
 TARGET = systemhook.dylib
-CC = clang
+CC = $(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
+CFLAGS = -I../.include -I./src -I../_external/modules/litehook/src --sysroot $(SDK_PATH) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -install_name @loader_path/$(TARGET) -Wno-deprecated-declarations -Os -moutline
 LDFLAGS = -dynamiclib
 
 sign: $(TARGET)

--- a/BaseBin/watchdoghook/Makefile
+++ b/BaseBin/watchdoghook/Makefile
@@ -1,7 +1,8 @@
 TARGET = watchdoghook.dylib
-CC = clang
+CC = $(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk iphoneos --show-sdk-path)
 
-CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src -isysroot $(shell xcrun --sdk iphoneos --show-sdk-path) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
+CFLAGS = -framework Foundation -framework CoreServices -framework Security -I../.include -I./src --sysroot $(SDK_PATH) -arch arm64 -arch arm64e -miphoneos-version-min=15.0 -fobjc-arc -O2
 LDFLAGS = -dynamiclib -rpath /var/jb/Library/Frameworks -rpath @loader_path/fallback -L../_external/lib -lellekit -framework IOKit
 
 sign: $(TARGET)

--- a/Exploits/oobPCI/Makefile
+++ b/Exploits/oobPCI/Makefile
@@ -1,12 +1,13 @@
 SDK=macosx
 TARGET=arm64-apple-macos12.0
 
-CC=xcrun -sdk $(SDK) clang
+CC=$(TOOLCHAIN)
+SDK_PATH ?= $(shell xcrun --sdk $(SDK) --show-sdk-path)
 
 WARNINGS=-Wall -Wpedantic -Werror
 NO_WARNINGS=-Wno-gnu-statement-expression -Wno-gnu-zero-variadic-macro-arguments -Wno-gnu-empty-struct -Wno-dollar-in-identifier-extension -Wno-language-extension-token -Wno-zero-length-array
-CFLAGS=-target $(TARGET) -D__arm64__ -D__aarch64__ -D__DARWIN_OPAQUE_ARM_THREAD_STATE64 -nostdlib -O0 $(WARNINGS) $(NO_WARNINGS)
-LDFLAGS=-target $(TARGET) -nostdlib -dead-strip -fpie -lSystem
+CFLAGS=-target $(TARGET) --sysroot $(SDK_PATH) -D__arm64__ -D__aarch64__ -D__DARWIN_OPAQUE_ARM_THREAD_STATE64 -nostdlib -O0 $(WARNINGS) $(NO_WARNINGS)
+LDFLAGS=-target $(TARGET) --sysroot $(SDK_PATH) -nostdlib -dead-strip -fpie -lSystem
 
 MIG_SOURCES=$(wildcard Sources/*.defs)
 MIG_GENERATED_SOURCES=$(addprefix Sources/generated/,$(patsubst %.defs,%.c,$(notdir $(MIG_SOURCES))))

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,16 @@
+ifeq ($(OS),Windows_NT)
+TOOLCHAIN ?= clang
+XATTR :=
+else
+TOOLCHAIN ?= xcrun -sdk iphoneos clang
+XATTR := xattr -rc Tools >/dev/null 2>&1
+endif
+
 all:
-	@./BaseBin/pack.sh
-	@xattr -rc Tools >/dev/null 2>&1
-	$(MAKE) -C Exploits/oobPCI
-	$(MAKE) -C Dopamine
+	@TOOLCHAIN="$(TOOLCHAIN)" SDK_PATH="$(SDK_PATH)" ./BaseBin/pack.sh
+	@$(if $(XATTR),$(XATTR),true)
+	$(MAKE) -C Exploits/oobPCI TOOLCHAIN="$(TOOLCHAIN)" SDK_PATH="$(SDK_PATH)"
+	$(MAKE) -C Dopamine TOOLCHAIN="$(TOOLCHAIN)" SDK_PATH="$(SDK_PATH)"
 
 %:
 	@echo "No target rule for $@"
@@ -12,3 +20,4 @@ clean:
 
 update: all
 	@./jbupdate.sh
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ Rootless arm64e jailbreak for iOS 15.0 - 15.4.1.
 
 Official website / download: https://xina.cypwn.xyz
 
+## Building on Windows
+
+1. Install LLVM/Clang. The easiest way is via [winget](https://learn.microsoft.com/windows/package-manager/winget/):
+
+   ```powershell
+   winget install -e --id LLVM.LLVM
+   ```
+
+   Alternatively download the LLVM installer from [llvm.org](https://releases.llvm.org/).
+
+2. Obtain an Apple SDK and set the toolchain and SDK paths before invoking `make`:
+
+   ```powershell
+   set TOOLCHAIN=clang
+   set SDK_PATH=C:\path\to\iPhoneOS.sdk
+   make
+   ```
+
+   (Use `$env:VAR="value"` in PowerShell.)
+
 ### Why Xinam1ne instead of Dopamine?
 
 Honestly, do what you want. Dopamine works fine to some extent. A lot of you ask me what changes with Xinam1ne and I always have to type out the same old stuff, so have a list of what Xinam1ne has that Dopamine doesn't:


### PR DESCRIPTION
## Summary
- detect Windows in root makefile, skip xattr, and propagate TOOLCHAIN
- allow BaseBin and oobPCI makefiles to use TOOLCHAIN and SDK_PATH
- document installing LLVM/Clang on Windows and setting TOOLCHAIN/SDK_PATH

## Testing
- `make TOOLCHAIN=clang SDK_PATH=/tmp` *(fails: `./BaseBin/pack.sh: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_689d9a644b60832da337d2ce2174c032