### PR TITLE
Add xcrun availability checks and document cross-platform build

### DIFF
--- a/Exploits/oobPCI/Makefile
+++ b/Exploits/oobPCI/Makefile
@@ -1,7 +1,16 @@
 SDK=macosx
 TARGET=arm64-apple-macos12.0
 
-CC=xcrun -sdk $(SDK) clang
+XCRUN := $(shell command -v xcrun 2>/dev/null)
+ifeq ($(XCRUN),)
+ifdef USE_SYSTEM_TOOLS
+CC := clang
+else
+$(error xcrun not found. Install Xcode command line tools or run 'make USE_SYSTEM_TOOLS=1' to use system clang.)
+endif
+else
+CC := xcrun -sdk $(SDK) clang
+endif
 
 WARNINGS=-Wall -Wpedantic -Werror
 NO_WARNINGS=-Wno-gnu-statement-expression -Wno-gnu-zero-variadic-macro-arguments -Wno-gnu-empty-struct -Wno-dollar-in-identifier-extension -Wno-language-extension-token -Wno-zero-length-array

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,23 @@
+XCRUN := \
+       $(shell command -v xcrun 2>/dev/null)
+
+ifndef XCRUN
+ifndef USE_SYSTEM_TOOLS
+$(error xcrun not found. Install Xcode command line tools or run 'make USE_SYSTEM_TOOLS=1' to use system clang.)
+endif
+endif
+
+export USE_SYSTEM_TOOLS
+
 all:
-	@./BaseBin/pack.sh
-	@xattr -rc Tools >/dev/null 2>&1
-	$(MAKE) -C Exploits/oobPCI
-	$(MAKE) -C Dopamine
+        @./BaseBin/pack.sh
+        @xattr -rc Tools >/dev/null 2>&1
+        $(MAKE) -C Exploits/oobPCI
+ifeq ($(XCRUN),)
+        @echo "Skipping Dopamine build: xcrun not found."
+else
+        $(MAKE) -C Dopamine
+endif
 
 %:
 	@echo "No target rule for $@"

--- a/README.md
+++ b/README.md
@@ -16,3 +16,15 @@ Honestly, do what you want. Dopamine works fine to some extent. A lot of you ask
 That's all folks!
 
 <img src="https://media.tenor.com/xvo8-YQ78P0AAAAC/porky-pig.gif)https://media.tenor.com/xvo8-YQ78P0AAAAC/porky-pig.gif" width="320" />
+
+## Building
+
+The default build process uses Apple's `xcrun` tool, which is provided by the Xcode command line tools. If `xcrun` is missing, `make` will exit with an error explaining that Xcode is required.
+
+You can attempt a cross-platform build by using system toolchains instead:
+
+```sh
+make USE_SYSTEM_TOOLS=1
+```
+
+This path relies on tools like `clang` being available on your system and may not support all features.


### PR DESCRIPTION
## Summary
- ensure top-level Makefile errors when `xcrun` is missing and export a flag to use system toolchains
- add fallback to `clang` in `Exploits/oobPCI` when `xcrun` isn't available
- document `xcrun` requirement and the `USE_SYSTEM_TOOLS=1` build option in README

## Testing
- `make` *(fails: xcrun not found)*
- `make USE_SYSTEM_TOOLS=1 -C Exploits/oobPCI` *(fails: 'mach/mach.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d9b92ce10832db0af4a6c79dee926