### PR TITLE
Vendor Mach headers for cross-platform builds

### DIFF
--- a/BaseBin/_external/include/mach/boolean.h
+++ b/BaseBin/_external/include/mach/boolean.h
@@ -1,0 +1,13 @@
+#ifndef _MACH_BOOLEAN_H_
+#define _MACH_BOOLEAN_H_
+
+typedef int boolean_t;
+
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#endif /* _MACH_BOOLEAN_H_ */

--- a/BaseBin/_external/include/mach/kern_return.h
+++ b/BaseBin/_external/include/mach/kern_return.h
@@ -1,0 +1,9 @@
+#ifndef _MACH_KERN_RETURN_H_
+#define _MACH_KERN_RETURN_H_
+
+typedef int kern_return_t;
+
+#define KERN_SUCCESS 0
+#define KERN_FAILURE 5
+
+#endif /* _MACH_KERN_RETURN_H_ */

--- a/BaseBin/_external/include/mach/mach.h
+++ b/BaseBin/_external/include/mach/mach.h
@@ -1,0 +1,16 @@
+#ifndef _MACH_MACH_H_
+#define _MACH_MACH_H_
+
+#include <mach/mach_types.h>
+#include <mach/message.h>
+#include <mach/mach_init.h>
+#include <mach/mach_vm.h>
+
+kern_return_t mach_port_allocate(mach_port_t task, mach_port_right_t right, mach_port_name_t *name);
+kern_return_t mach_port_insert_right(mach_port_t task, mach_port_name_t name, mach_port_t poly, mach_msg_type_name_t right);
+kern_return_t mach_port_deallocate(mach_port_t task, mach_port_name_t name);
+kern_return_t mach_ports_lookup(mach_port_t task, mach_port_t **names, mach_msg_type_number_t *nameCnt);
+kern_return_t mach_ports_register(mach_port_t task, mach_port_array_t names, mach_msg_type_number_t nameCnt);
+kern_return_t task_for_pid(mach_port_t target_tport, int pid, mach_port_name_t *task);
+
+#endif /* _MACH_MACH_H_ */

--- a/BaseBin/_external/include/mach/mach_init.h
+++ b/BaseBin/_external/include/mach/mach_init.h
@@ -1,0 +1,10 @@
+#ifndef _MACH_MACH_INIT_H_
+#define _MACH_MACH_INIT_H_
+
+#include <mach/port.h>
+
+mach_port_t mach_task_self(void);
+mach_port_t mach_host_self(void);
+mach_port_t mach_thread_self(void);
+
+#endif /* _MACH_MACH_INIT_H_ */

--- a/BaseBin/_external/include/mach/mach_types.h
+++ b/BaseBin/_external/include/mach/mach_types.h
@@ -1,0 +1,29 @@
+#ifndef _MACH_MACH_TYPES_H_
+#define _MACH_MACH_TYPES_H_
+
+#include <stdint.h>
+#include <mach/port.h>
+#include <mach/kern_return.h>
+
+typedef int             integer_t;
+typedef int             natural_t;
+
+typedef mach_port_t task_t;
+typedef mach_port_t thread_t;
+typedef mach_port_t host_t;
+typedef mach_port_t vm_map_t;
+
+typedef uint64_t mach_vm_address_t;
+typedef uint64_t mach_vm_size_t;
+typedef uint64_t vm_address_t;
+typedef uint64_t vm_size_t;
+typedef int      vm_prot_t;
+
+typedef int cpu_type_t;
+typedef int cpu_subtype_t;
+
+typedef mach_port_t *thread_act_array_t;
+
+typedef unsigned int mach_msg_type_number_t;
+
+#endif /* _MACH_MACH_TYPES_H_ */

--- a/BaseBin/_external/include/mach/mach_vm.h
+++ b/BaseBin/_external/include/mach/mach_vm.h
@@ -1,0 +1,24 @@
+#ifndef _MACH_MACH_VM_H_
+#define _MACH_MACH_VM_H_
+
+#include <mach/mach_types.h>
+#include <mach/vm_prot.h>
+#include <mach/boolean.h>
+
+typedef mach_port_t vm_map_t;
+
+typedef kern_return_t (*mach_vm_allocate_fn)(vm_map_t, mach_vm_address_t *, mach_vm_size_t, int);
+
+enum {
+    VM_FLAGS_ANYWHERE    = 0x0001,
+    VM_FLAGS_PURGABLE    = 0x0002,
+    VM_FLAGS_RANDOM_ADDR = 0x0008
+};
+
+kern_return_t mach_vm_allocate(vm_map_t target, mach_vm_address_t *address, mach_vm_size_t size, int flags);
+kern_return_t mach_vm_deallocate(vm_map_t target, mach_vm_address_t address, mach_vm_size_t size);
+kern_return_t mach_vm_protect(vm_map_t target, mach_vm_address_t address, mach_vm_size_t size, boolean_t set_max, vm_prot_t new_prot);
+kern_return_t vm_protect(vm_map_t target, mach_vm_address_t address, mach_vm_size_t size, boolean_t set_max, vm_prot_t new_prot);
+kern_return_t vm_allocate(vm_map_t target, mach_vm_address_t *address, mach_vm_size_t size, int flags);
+
+#endif /* _MACH_MACH_VM_H_ */

--- a/BaseBin/_external/include/mach/machine.h
+++ b/BaseBin/_external/include/mach/machine.h
@@ -1,0 +1,7 @@
+#ifndef _MACH_MACHINE_H_
+#define _MACH_MACHINE_H_
+
+typedef int cpu_type_t;
+typedef int cpu_subtype_t;
+
+#endif /* _MACH_MACHINE_H_ */

--- a/BaseBin/_external/include/mach/message.h
+++ b/BaseBin/_external/include/mach/message.h
@@ -1,0 +1,24 @@
+#ifndef _MACH_MESSAGE_H_
+#define _MACH_MESSAGE_H_
+
+#include <stdint.h>
+#include <mach/port.h>
+
+typedef uint32_t mach_msg_bits_t;
+typedef uint32_t mach_msg_size_t;
+typedef int32_t mach_msg_id_t;
+typedef int mach_msg_return_t;
+typedef unsigned int mach_msg_type_number_t;
+
+typedef struct {
+    mach_msg_bits_t msgh_bits;
+    mach_msg_size_t msgh_size;
+    mach_port_t msgh_remote_port;
+    mach_port_t msgh_local_port;
+    mach_msg_size_t msgh_reserved;
+    mach_msg_id_t msgh_id;
+} mach_msg_header_t;
+
+#define MACH_MSG_TYPE_MAKE_SEND 20
+
+#endif /* _MACH_MESSAGE_H_ */

--- a/BaseBin/_external/include/mach/mig_errors.h
+++ b/BaseBin/_external/include/mach/mig_errors.h
@@ -1,0 +1,15 @@
+#ifndef _MACH_MIG_ERRORS_H_
+#define _MACH_MIG_ERRORS_H_
+
+#define MIG_TYPE_ERROR      (-300)
+#define MIG_REPLY_MISMATCH  (-301)
+#define MIG_REMOTE_ERROR    (-302)
+#define MIG_BAD_ID          (-303)
+#define MIG_BAD_ARGUMENTS   (-304)
+#define MIG_NO_REPLY        (-305)
+#define MIG_EXCEPTION       (-306)
+#define MIG_ARRAY_TOO_LARGE (-307)
+#define MIG_SERVER_DIED     (-308)
+#define MIG_TRAILER_ERROR   (-309)
+
+#endif /* _MACH_MIG_ERRORS_H_ */

--- a/BaseBin/_external/include/mach/ndr.h
+++ b/BaseBin/_external/include/mach/ndr.h
@@ -1,0 +1,15 @@
+#ifndef _MACH_NDR_H_
+#define _MACH_NDR_H_
+
+typedef struct {
+    unsigned char mig_vers;
+    unsigned char if_vers;
+    unsigned char reserved1;
+    unsigned char mig_encoding;
+    unsigned char int_rep;
+    unsigned char char_rep;
+    unsigned char float_rep;
+    unsigned char reserved2;
+} NDR_record_t;
+
+#endif /* _MACH_NDR_H_ */

--- a/BaseBin/_external/include/mach/notify.h
+++ b/BaseBin/_external/include/mach/notify.h
@@ -1,0 +1,12 @@
+#ifndef _MACH_NOTIFY_H_
+#define _MACH_NOTIFY_H_
+
+#include <mach/port.h>
+#include <mach/message.h>
+
+#define MACH_NOTIFY_PORT_DESTROYED 0
+#define MACH_NOTIFY_PORT_DELETED   0
+#define MACH_NOTIFY_SEND_POSSIBLE  0
+#define MACH_NOTIFY_DEAD_NAME      0
+
+#endif /* _MACH_NOTIFY_H_ */

--- a/BaseBin/_external/include/mach/port.h
+++ b/BaseBin/_external/include/mach/port.h
@@ -1,0 +1,24 @@
+#ifndef _MACH_PORT_H_
+#define _MACH_PORT_H_
+
+#include <stdint.h>
+#include <mach/kern_return.h>
+#include <mach/boolean.h>
+
+typedef uint32_t mach_port_t;
+typedef mach_port_t mach_port_name_t;
+typedef mach_port_t *mach_port_array_t;
+typedef int mach_port_right_t;
+
+typedef int mach_msg_type_name_t;
+
+#define MACH_PORT_NULL 0
+#define MACH_PORT_DEAD ((mach_port_t)~0)
+
+#define MACH_PORT_RIGHT_SEND          ((mach_port_right_t)1)
+#define MACH_PORT_RIGHT_RECEIVE       ((mach_port_right_t)2)
+#define MACH_PORT_RIGHT_SEND_ONCE     ((mach_port_right_t)3)
+#define MACH_PORT_RIGHT_PORT_SET      ((mach_port_right_t)4)
+#define MACH_PORT_RIGHT_DEAD_NAME     ((mach_port_right_t)5)
+
+#endif /* _MACH_PORT_H_ */

--- a/BaseBin/_external/include/mach/vm_prot.h
+++ b/BaseBin/_external/include/mach/vm_prot.h
@@ -1,0 +1,13 @@
+#ifndef _MACH_VM_PROT_H_
+#define _MACH_VM_PROT_H_
+
+typedef int vm_prot_t;
+
+#define VM_PROT_NONE    0x00
+#define VM_PROT_READ    0x01
+#define VM_PROT_WRITE   0x02
+#define VM_PROT_EXECUTE 0x04
+#define VM_PROT_DEFAULT (VM_PROT_READ|VM_PROT_WRITE)
+#define VM_PROT_ALL     (VM_PROT_READ|VM_PROT_WRITE|VM_PROT_EXECUTE)
+
+#endif /* _MACH_VM_PROT_H_ */

--- a/Exploits/oobPCI/Makefile
+++ b/Exploits/oobPCI/Makefile
@@ -1,11 +1,12 @@
 SDK=macosx
 TARGET=arm64-apple-macos12.0
+PROJECT_ROOT := $(realpath $(CURDIR)/../..)
 
 CC=xcrun -sdk $(SDK) clang
 
 WARNINGS=-Wall -Wpedantic -Werror
 NO_WARNINGS=-Wno-gnu-statement-expression -Wno-gnu-zero-variadic-macro-arguments -Wno-gnu-empty-struct -Wno-dollar-in-identifier-extension -Wno-language-extension-token -Wno-zero-length-array
-CFLAGS=-target $(TARGET) -D__arm64__ -D__aarch64__ -D__DARWIN_OPAQUE_ARM_THREAD_STATE64 -nostdlib -O0 $(WARNINGS) $(NO_WARNINGS)
+CFLAGS=-target $(TARGET) -D__arm64__ -D__aarch64__ -D__DARWIN_OPAQUE_ARM_THREAD_STATE64 -nostdlib -O0 $(WARNINGS) $(NO_WARNINGS) -I$(PROJECT_ROOT)/BaseBin/_external/include
 LDFLAGS=-target $(TARGET) -nostdlib -dead-strip -fpie -lSystem
 
 MIG_SOURCES=$(wildcard Sources/*.defs)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Honestly, do what you want. Dopamine works fine to some extent. A lot of you ask
 - Xina-like symlinks for older rootful tweaks which are created upon jailbreaking (so DRM for said tweaks can load w/o issue in rare cases)
 - Cypwn-oriented colors
 - A toggle to stay on stock Dopamine vs. Xinam1ne w/ symlinks
+### Building
+
+Cross-platform builds require the vendored Darwin headers located in `BaseBin/_external/include` or an extracted macOS/iOS SDK.
+
 
 That's all folks!
 


### PR DESCRIPTION
## Summary
- vendor a minimal set of Darwin Mach headers in `BaseBin/_external/include/mach`
- allow the oobPCI exploit to find those headers by adding the directory to `CFLAGS`
- note in the README that non-Apple builds require vendored headers or a macOS/iOS SDK

## Testing
- `make -C Exploits/oobPCI build_clean`
- `make -C Exploits/oobPCI` *(fails: `xcrun: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_689d9e0656b4832d93179252fbe4faae