### PR TITLE
Include Mach headers in oobPCI stubs

### DIFF
--- a/Exploits/oobPCI/Sources/generated/device.c
+++ b/Exploits/oobPCI/Sources/generated/device.c
@@ -6,8 +6,7 @@
 #define	__MIG_check__Reply__iokit_subsystem__ 1
 
 #include "device.h"
-
-/* TODO: #include <mach/mach.h> */
+#include <mach/mach.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/mach_host.c
+++ b/Exploits/oobPCI/Sources/generated/mach_host.c
@@ -6,8 +6,7 @@
 #define	__MIG_check__Reply__mach_host_subsystem__ 1
 
 #include "mach_host.h"
-
-/* TODO: #include <mach/mach.h> */
+#include <mach/mach.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/task.c
+++ b/Exploits/oobPCI/Sources/generated/task.c
@@ -6,8 +6,7 @@
 #define	__MIG_check__Reply__task_subsystem__ 1
 
 #include "task.h"
-
-/* TODO: #include <mach/mach.h> */
+#include <mach/mach.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/thread.c
+++ b/Exploits/oobPCI/Sources/generated/thread.c
@@ -6,8 +6,7 @@
 #define	__MIG_check__Reply__thread_act_subsystem__ 1
 
 #include "thread.h"
-
-/* TODO: #include <mach/mach.h> */
+#include <mach/mach.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */


### PR DESCRIPTION
## Summary
- include <mach/mach.h> in generated mach_host, thread, task, and device stubs

## Testing
- `make -C Exploits/oobPCI` *(fails: xcrun: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689da118502c832db38d00e30cf4ef4d