### PR TITLE
Add DriverKit service cleanup and logging

### DIFF
--- a/Exploits/oobPCI/Sources/main.c
+++ b/Exploits/oobPCI/Sources/main.c
@@ -10,6 +10,7 @@
 #include <sys/errno.h>
 #include <IOKit/IOKitLib.h>
 #include <stdbool.h>
+#include <mach/mach.h>
 
 #include "includeme.h"
 #include "oobPCI.h"
@@ -76,22 +77,43 @@ bool platformize(uint64_t proc) {
     return true;
 }
 
-void terminateService(mach_port_t service) {
+bool terminateService(mach_port_t service) {
     uint64_t ourService = portKObject(service);
     uint64_t ourServiceVTable = kread_ptr(ourService);
     guard (ourServiceVTable != 0) else {
-        puts("Failed to read our service VTable!");
-        exit(-1);
+        puts("terminateService: Failed to read service VTable!");
+        return false;
     }
-    
+
     uint64_t terminateFunc = kread_ptr(ourServiceVTable + 0x2F8);
     guard (terminateFunc != 0) else {
-        puts("Failed to get terminate func!");
-        exit(-1);
+        puts("terminateService: Failed to get terminate func!");
+        return false;
     }
-    
-    //kcall(terminateFunc, ourService, 0x103, 0, 0, 0, 0, 0, 0);
-    kcall(terminateFunc, ourService, 0, 0, 0, 0, 0, 0, 0);
+
+    uint64_t ret = kcall(terminateFunc, ourService, 0, 0, 0, 0, 0, 0, 0);
+    printf("terminateService(%u) => %p\n", service, (void*)ret);
+    return ret == 0;
+}
+
+static void cleanupDKServices(void) {
+    puts("[*] Cleaning up DriverKit services");
+
+    if (gDKServerPort) {
+        if (!terminateService(gDKServerPort)) {
+            puts("[-] Failed to terminate gDKServerPort; service will persist until exit");
+        }
+        mach_port_deallocate(mach_task_self_, gDKServerPort);
+        gDKServerPort = MACH_PORT_NULL;
+    }
+
+    if (gDKOrigServerPort) {
+        if (!terminateService(gDKOrigServerPort)) {
+            puts("[-] Failed to terminate gDKOrigServerPort; service will persist until exit");
+        }
+        mach_port_deallocate(mach_task_self_, gDKOrigServerPort);
+        gDKOrigServerPort = MACH_PORT_NULL;
+    }
 }
 
 void PCIDevice_setBusMasterAndMemoryAccessEnable(mach_port_t port, bool enable)
@@ -213,9 +235,9 @@ void __attribute__((noreturn)) exploit_server(uint64_t kBase, uint64_t virtBase,
     PCIDevice_setBusMasterAndMemoryAccessEnable(gIOPCIDev, true);
     
     // Fix PM Bug
-    // FIXME: Doesn't work unless this application exits
-    //terminateService(gDKServerPort);
-    //terminateService(gDKOrigServerPort);
+    // Attempt to terminate DriverKit services while staying alive
+    // If termination fails, services remain until the process exits
+    cleanupDKServices();
     
     // Platformize us...
     /*platformize(gOurProc);


### PR DESCRIPTION
## Summary
- add `terminateService` return value and logging
- add `cleanupDKServices` to terminate and deallocate DriverKit ports
- document limitation when service termination fails at runtime

## Testing
- `make` *(fails: xcrun: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689da11a9ca0832dba889658b9b1cd9d