### PR TITLE
Propagate deleteBootstrap errors

### DIFF
--- a/Dopamine/Jailbreak/DOEnvironmentManager.m
+++ b/Dopamine/Jailbreak/DOEnvironmentManager.m
@@ -644,7 +644,7 @@ int reboot3(uint64_t flags, ...);
     if (![self isJailbroken] && getuid() != 0) {
         int r = [self runTrollStoreAction:@"delete-bootstrap"];
         if (r != 0) {
-            // TODO: maybe handle error
+            return [NSError errorWithDomain:@"Dopamine" code:r userInfo:nil];
         }
         return nil;
     }

--- a/Dopamine/UI/Settings/DOSettingsController.m
+++ b/Dopamine/UI/Settings/DOSettingsController.m
@@ -516,7 +516,13 @@
 {
     UIAlertController *confirmationAlertController = [UIAlertController alertControllerWithTitle:DOLocalizedString(@"Alert_Remove_Jailbreak_Title") message:DOLocalizedString(@"Alert_Remove_Jailbreak_Pressed_Body") preferredStyle:UIAlertControllerStyleAlert];
     UIAlertAction *uninstallAction = [UIAlertAction actionWithTitle:DOLocalizedString(@"Button_Continue") style:UIAlertActionStyleDestructive handler:^(UIAlertAction * _Nonnull action) {
-        [[DOEnvironmentManager sharedManager] deleteBootstrap];
+        NSError *error = [[DOEnvironmentManager sharedManager] deleteBootstrap];
+        if (error) {
+            UIAlertController *alert = [UIAlertController alertControllerWithTitle:DOLocalizedString(@"Alert_Remove_Jailbreak_Title") message:error.localizedDescription preferredStyle:UIAlertControllerStyleAlert];
+            [alert addAction:[UIAlertAction actionWithTitle:DOLocalizedString(@"Button_Close") style:UIAlertActionStyleDefault handler:nil]];
+            [self presentViewController:alert animated:YES completion:nil];
+            return;
+        }
         if ([DOEnvironmentManager sharedManager].isJailbroken) {
             [[DOEnvironmentManager sharedManager] reboot];
         }

--- a/Dopamine/main.m
+++ b/Dopamine/main.m
@@ -16,7 +16,11 @@ int main(int argc, char * argv[]) {
     if (argc >= 3) {
         if (!strcmp(argv[1], "trollstore")) {
             if (!strcmp(argv[2], "delete-bootstrap")) {
-                [[DOEnvironmentManager sharedManager] deleteBootstrap];
+                NSError *error = [[DOEnvironmentManager sharedManager] deleteBootstrap];
+                if (error) {
+                    fprintf(stderr, "Failed to delete bootstrap: %s\n", error.localizedDescription.UTF8String);
+                    return (int)error.code;
+                }
             }
             else if (!strcmp(argv[2], "hide-jailbreak")) {
                 [[DOEnvironmentManager sharedManager] setJailbreakHidden:YES];


### PR DESCRIPTION
## Summary
- return NSError when TrollStore deletion fails
- surface deletion errors in main entry point
- present alerts for jailbreak removal errors in settings

## Testing
- `make` *(fails: ./BaseBin/pack.sh: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689da11b0e74832d9ec206101f13e859