### PR TITLE
Zero-fill FileStream writes beyond EOF

### DIFF
--- a/BaseBin/ChOma/FileStream.c
+++ b/BaseBin/ChOma/FileStream.c
@@ -1,7 +1,9 @@
 #include "FileStream.h"
 #include <sys/fcntl.h>
 #include <errno.h>
+#ifdef __APPLE__
 #include <os/log.h>
+#endif
 
 static int _file_stream_context_is_trimmed(FileStreamContext *context)
 {
@@ -35,8 +37,15 @@ static int file_stream_write(MemoryStream *stream, uint64_t offset, size_t size,
         sizeToExpand = (context->bufferStart + offset + size) - context->fileSize;
     }
 
-    // this is not supported for now: TODO fill with 0's then append the rest
-    if (context->bufferStart + offset > context->fileSize) return -1;
+    size_t gapLen = 0;
+    if (context->bufferStart + offset > context->fileSize) {
+        gapLen = (context->bufferStart + offset) - context->fileSize;
+        void *zeroBuf = calloc(1, gapLen);
+        if (!zeroBuf) return -1;
+        lseek(context->fd, context->fileSize, SEEK_SET);
+        write(context->fd, zeroBuf, gapLen);
+        free(zeroBuf);
+    }
 
     context->fileSize += sizeToExpand;
     context->bufferSize += sizeToExpand;

--- a/BaseBin/ChOma/tests/FileStreamTests.c
+++ b/BaseBin/ChOma/tests/FileStreamTests.c
@@ -1,0 +1,42 @@
+#include "FileStream.h"
+#include <assert.h>
+#include <string.h>
+#include <stdio.h>
+
+int memory_stream_copy_data(MemoryStream *originStream, uint64_t originOffset,
+                            MemoryStream *targetStream, uint64_t targetOffset,
+                            size_t size) {
+    return -1;
+}
+
+int main() {
+    FILE *tmp = tmpfile();
+    if (!tmp) return 1;
+    int fd = fileno(tmp);
+
+    MemoryStream *stream = file_stream_init_from_file_descriptor(fd, 0, FILE_STREAM_SIZE_AUTO,
+        FILE_STREAM_FLAG_WRITABLE | FILE_STREAM_FLAG_AUTO_EXPAND);
+    if (!stream) return 1;
+
+    const char data[] = { 'A', 'B', 'C', 'D' };
+    int wr = stream->write(stream, 8, sizeof(data), data);
+    assert(wr == sizeof(data));
+
+    size_t size = 0;
+    stream->getSize(stream, &size);
+    assert(size == 12);
+
+    lseek(fd, 0, SEEK_SET);
+    char buf[12];
+    memset(buf, 0, sizeof(buf));
+    read(fd, buf, sizeof(buf));
+
+    for (int i = 0; i < 8; i++) {
+        assert(buf[i] == 0);
+    }
+    assert(memcmp(buf + 8, data, sizeof(data)) == 0);
+
+    stream->free(stream);
+    fclose(tmp);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- fill gaps with zero bytes when writing beyond end-of-file in `file_stream_write`
- add unit test ensuring gaps are zero-filled and file size grows as expected

## Testing
- `clang -include stdint.h -I BaseBin/ChOma BaseBin/ChOma/FileStream.c BaseBin/ChOma/tests/FileStreamTests.c -o /tmp/FileStreamTests && /tmp/FileStreamTests`


------
https://chatgpt.com/codex/tasks/task_e_689da1159edc832da89e8428557d1803