### PR TITLE
Use program handle when unloading ANE model

### DIFF
--- a/Dopamine/Exploits/weightBufs/exploit/exploit.h
+++ b/Dopamine/Exploits/weightBufs/exploit/exploit.h
@@ -108,7 +108,7 @@ void hwx_patch_model(void);
 void _hwx_patch_model(struct mach_header_64 *,size_t ,u8 ** );
 uint64_t hwx_load_model(void);
 uint64_t hwx_patch_and_load_model(void);
-void hwx_unload_model(u64);
+void hwx_unload_model(u64 program_handle);
 
 
 int exploit(uint64_t *kernelBaseOut);

--- a/Dopamine/Exploits/weightBufs/exploit/exploit.m
+++ b/Dopamine/Exploits/weightBufs/exploit/exploit.m
@@ -245,14 +245,17 @@ uint64_t hwx_load_model(void)
 
 }
 
- /* TODO : use program_handle arg */
-void hwx_unload_model(u64 /* unused */ program_handle)
+void hwx_unload_model(u64 program_handle)
 {
         dbg("[+] Unload program ... ");
         NSError *err = nil;
         NSDictionary *opts = [NSMutableDictionary dictionary];
-        [anec purgeCompiledModel:md];
-        [anec unloadModel:md options:opts qos:1 error:&err];
+
+        id model = [_ANEModel new];
+        [model setProgramHandle:program_handle];
+
+        [anec purgeCompiledModel:model];
+        [anec unloadModel:model options:opts qos:1 error:&err];
         dbg("OK\n");
 }
 


### PR DESCRIPTION
## Summary
- Update `hwx_unload_model` to create a temporary model from the provided program handle and use it for purge/unload operations.
- Expose the program handle parameter in the header declaration.

## Testing
- `make` *(fails: Permission denied on BaseBin/pack.sh)*
- `clang -c Dopamine/Exploits/weightBufs/exploit/exploit.m -o /tmp/exploit.o` *(fails: 'mach/mach.h' file not found)*


------
https://chatgpt.com/codex/tasks/task_e_689da11c737c832da29a152cbcd5807f