### PR TITLE
Use header-based thread_id offset for kfd

### DIFF
--- a/Dopamine/Exploits/kfd/kfd.m
+++ b/Dopamine/Exploits/kfd/kfd.m
@@ -4,9 +4,43 @@
 #import <libjailbreak/info.h>
 #import <libjailbreak/primitives_external.h>
 #import <os/proc.h>
+#import <sys/sysctl.h>
+
+#if __has_include(<kern/thread.h>)
+#import <kern/thread.h>
+#endif
 
 
 uint64_t gKfd = 0;
+
+#if __has_include(<kern/thread.h>)
+static uint64_t thread_id_offset(void) {
+    return koffsetof(thread, thread_id);
+}
+#else
+static uint64_t thread_id_offset(void) {
+    struct thread_id_offset_entry {
+        const char *os_release;
+        uint64_t offset;
+    };
+    static const struct thread_id_offset_entry table[] = {
+        {"21.", 0x400}, // iOS 15
+        {"22.", 0x400}, // iOS 16
+        {"23.", 0x400}, // iOS 17
+    };
+    char os_release[32] = {0};
+    size_t sz = sizeof(os_release);
+    if (sysctlbyname("kern.osrelease", os_release, &sz, NULL, 0) != 0) {
+        return 0;
+    }
+    for (size_t i = 0; i < sizeof(table) / sizeof(table[0]); i++) {
+        if (strncmp(os_release, table[i].os_release, strlen(table[i].os_release)) == 0) {
+            return table[i].offset;
+        }
+    }
+    return 0;
+}
+#endif
 
 uint8_t kread8(uint64_t where) {
     uint64_t out;
@@ -195,7 +229,7 @@ int exploit_init(const char *flavor)
         .IOSurface__indexedTimestampPtr = 0x360,
         .IOSurface__readDisplacement    =  0x14,
 
-        .thread__thread_id = 0x400, // TODO: Universalize (Only relevant for kread_kqueue_workloop_ctl)
+        .thread__thread_id = thread_id_offset(),
 
         .kernelcache__allproc          = ksymbol(allproc),
         


### PR DESCRIPTION
## Summary
- Compute `thread_id` offset using `<kern/thread.h>` when available
- Fallback to Darwin version-based constants when kernel headers are missing
- Populate `dynamic_system_info.thread__thread_id` with the computed offset

## Testing
- `clang -fsyntax-only Dopamine/Exploits/kfd/kfd.m` *(fails: 'mach/mach.h' file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689da3d1b49c832d9d462dffd0ce131b