### PR TITLE
Add Makefile test rule and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,5 +10,10 @@ all:
 clean:
 	@./BaseBin/clean.sh
 
+test:
+	@echo "Checking shell script syntax..."
+	@find . -name '*.sh' -print0 | xargs -0 -n1 sh -n
+	@echo "All shell scripts parsed successfully."
+
 update: all
 	@./jbupdate.sh

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Rootless arm64e jailbreak for iOS 15.0 - 15.4.1.
 
 Official website / download: https://xina.cypwn.xyz
 
+## Testing
+
+To perform a basic syntax check on all shell scripts in the repository, run:
+
+```
+make test
+```
+
+The command fails if any script contains a syntax error, allowing quick verification after making changes.
+
 ### Why Xinam1ne instead of Dopamine?
 
 Honestly, do what you want. Dopamine works fine to some extent. A lot of you ask me what changes with Xinam1ne and I always have to type out the same old stuff, so have a list of what Xinam1ne has that Dopamine doesn't:


### PR DESCRIPTION
## Summary
- add `test` rule to Makefile for shell script syntax checks
- document `make test` usage in README

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689da3d861d4832d889d8a46825e0014