### PR TITLE
guard Mach include with fallback

### DIFF
--- a/Dopamine/Exploits/kfd/Exploit/libkfd/common.h
+++ b/Dopamine/Exploits/kfd/Exploit/libkfd/common.h
@@ -6,7 +6,14 @@
 #define common_h
 
 #include <errno.h>
+#if __has_include(<mach/mach.h>)
 #include <mach/mach.h>
+#else
+typedef int kern_return_t;
+static inline const char *mach_error_string(kern_return_t kret) { return "mach/mach.h unavailable"; }
+#define KERN_SUCCESS 0
+#warning "mach/mach.h not found; using stub definitions"
+#endif
 #include <pthread.h>
 #include <semaphore.h>
 #include <stdatomic.h>


### PR DESCRIPTION
## Summary
- conditionally include `mach/mach.h` and provide stub replacements when unavailable

## Testing
- `make` *(fails: `./BaseBin/pack.sh: Permission denied`)*

------
https://chatgpt.com/codex/tasks/task_e_689da6031954832d824f323a038bc7a1