### PR TITLE
Fix broken README image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Honestly, do what you want. Dopamine works fine to some extent. A lot of you ask
 
 That's all folks!
 
-<img src="https://media.tenor.com/xvo8-YQ78P0AAAAC/porky-pig.gif)https://media.tenor.com/xvo8-YQ78P0AAAAC/porky-pig.gif" width="320" />
+<img src="https://media.tenor.com/xvo8-YQ78P0AAAAC/porky-pig.gif" width="320" />


### PR DESCRIPTION
## Summary
- remove stray parenthesis and duplicate link from README's final image

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689da891079c832da2eb3241a89d7519