### PR TITLE
Handle error from TrollStore bootstrap deletion

### DIFF
--- a/Dopamine/Jailbreak/DOEnvironmentManager.m
+++ b/Dopamine/Jailbreak/DOEnvironmentManager.m
@@ -644,7 +644,9 @@ int reboot3(uint64_t flags, ...);
     if (![self isJailbroken] && getuid() != 0) {
         int r = [self runTrollStoreAction:@"delete-bootstrap"];
         if (r != 0) {
-            // TODO: maybe handle error
+            NSString *desc = [NSString stringWithFormat:@"TrollStore action delete-bootstrap failed with code %d", r];
+            NSLog(@"%@", desc);
+            return [NSError errorWithDomain:@"Dopamine" code:r userInfo:@{NSLocalizedDescriptionKey: desc}];
         }
         return nil;
     }


### PR DESCRIPTION
## Summary
- Handle non-zero return when requesting TrollStore to delete the bootstrap
- Log a descriptive message and return an NSError instead of silently succeeding

## Testing
- `make` *(fails: Permission denied on BaseBin/pack.sh)*

------
https://chatgpt.com/codex/tasks/task_e_689da893b490832d95c217df4334634c