### PR TITLE
Add bounds checking to buffered_stream_trim

### DIFF
--- a/BaseBin/ChOma/BufferedStream.c
+++ b/BaseBin/ChOma/BufferedStream.c
@@ -71,7 +71,13 @@ static int buffered_stream_trim(MemoryStream *stream, size_t trimAtStart, size_t
 {
     BufferedStreamContext *context = stream->context;
 
-    // TODO: bound checks
+    if (trimAtStart > context->subBufferSize || trimAtEnd > context->subBufferSize ||
+        trimAtStart > context->subBufferSize - trimAtEnd) {
+        printf("Error: cannot trim %zx bytes at start and %zx bytes at end, maximum is %zx.\n",
+               trimAtStart, trimAtEnd, context->subBufferSize);
+        return -1;
+    }
+
     context->subBufferStart += trimAtStart;
     context->subBufferSize -= (trimAtEnd + trimAtStart);
 


### PR DESCRIPTION
## Summary
- Validate trim requests in `buffered_stream_trim`
- Return error when requested trim exceeds available buffer

## Testing
- `gcc -IBaseBin/ChOma -include stdint.h -c BaseBin/ChOma/BufferedStream.c -o /tmp/BufferedStream.o`

------
https://chatgpt.com/codex/tasks/task_e_689da894de84832db762b66173f8da4a