### PR TITLE
Add compiler fallback in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,20 @@
+# Determine a usable compiler
+XCRUN := $(shell command -v xcrun 2>/dev/null)
+
+ifeq ($(XCRUN),)
+    # "xcrun" not available; keep existing CC if it resolves to a compiler
+    ifeq ($(shell command -v $(CC) 2>/dev/null),)
+        CC := $(shell command -v clang 2>/dev/null)
+    endif
+    ifeq ($(CC),)
+        $(warning Neither xcrun nor a usable compiler was found.\nInstall Xcode command line tools or set the CC environment variable.)
+    endif
+else
+    CC := $(shell xcrun --find clang)
+endif
+
+export CC
+
 all:
 	@./BaseBin/pack.sh
 	@xattr -rc Tools >/dev/null 2>&1


### PR DESCRIPTION
## Summary
- detect `xcrun` before building and fall back to `clang` or `$CC`
- warn when no suitable compiler is available

## Testing
- `make -n all` (fails: No targets specified and no makefile found)
- `make clean` (fails: ./BaseBin/clean.sh: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_689dab0bd010832db883ce8f7fa6a1d4