### PR TITLE
Include Mach headers in oobPCI generated stubs

### DIFF
--- a/Exploits/oobPCI/Sources/generated/device.c
+++ b/Exploits/oobPCI/Sources/generated/device.c
@@ -8,7 +8,6 @@
 #include "device.h"
 
 #include <mach/mach.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/device.c
+++ b/Exploits/oobPCI/Sources/generated/device.c
@@ -6,6 +6,7 @@
 #define	__MIG_check__Reply__iokit_subsystem__ 1
 
 #include "device.h"
+
 #include <mach/mach.h>
 
 #ifdef __cplusplus

--- a/Exploits/oobPCI/Sources/generated/device.c
+++ b/Exploits/oobPCI/Sources/generated/device.c
@@ -6,8 +6,7 @@
 #define	__MIG_check__Reply__iokit_subsystem__ 1
 
 #include "device.h"
-
-/* TODO: #include <mach/mach.h> */
+#include <mach/mach.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/device.c
+++ b/Exploits/oobPCI/Sources/generated/device.c
@@ -7,6 +7,7 @@
 
 #include "device.h"
 #include <mach/mach.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/device.c
+++ b/Exploits/oobPCI/Sources/generated/device.c
@@ -8,6 +8,7 @@
 #include "device.h"
 
 #include <mach/mach.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/mach_host.c
+++ b/Exploits/oobPCI/Sources/generated/mach_host.c
@@ -6,6 +6,7 @@
 #define	__MIG_check__Reply__mach_host_subsystem__ 1
 
 #include "mach_host.h"
+
 #include <mach/mach.h>
 
 #ifdef __cplusplus

--- a/Exploits/oobPCI/Sources/generated/mach_host.c
+++ b/Exploits/oobPCI/Sources/generated/mach_host.c
@@ -8,6 +8,7 @@
 #include "mach_host.h"
 
 #include <mach/mach.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/mach_host.c
+++ b/Exploits/oobPCI/Sources/generated/mach_host.c
@@ -8,7 +8,6 @@
 #include "mach_host.h"
 
 #include <mach/mach.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/mach_host.c
+++ b/Exploits/oobPCI/Sources/generated/mach_host.c
@@ -7,6 +7,7 @@
 
 #include "mach_host.h"
 #include <mach/mach.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/mach_host.c
+++ b/Exploits/oobPCI/Sources/generated/mach_host.c
@@ -6,8 +6,7 @@
 #define	__MIG_check__Reply__mach_host_subsystem__ 1
 
 #include "mach_host.h"
-
-/* TODO: #include <mach/mach.h> */
+#include <mach/mach.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/task.c
+++ b/Exploits/oobPCI/Sources/generated/task.c
@@ -6,8 +6,7 @@
 #define	__MIG_check__Reply__task_subsystem__ 1
 
 #include "task.h"
-
-/* TODO: #include <mach/mach.h> */
+#include <mach/mach.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/task.c
+++ b/Exploits/oobPCI/Sources/generated/task.c
@@ -8,6 +8,7 @@
 #include "task.h"
 
 #include <mach/mach.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/task.c
+++ b/Exploits/oobPCI/Sources/generated/task.c
@@ -6,6 +6,7 @@
 #define	__MIG_check__Reply__task_subsystem__ 1
 
 #include "task.h"
+
 #include <mach/mach.h>
 
 #ifdef __cplusplus

--- a/Exploits/oobPCI/Sources/generated/task.c
+++ b/Exploits/oobPCI/Sources/generated/task.c
@@ -7,6 +7,7 @@
 
 #include "task.h"
 #include <mach/mach.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/task.c
+++ b/Exploits/oobPCI/Sources/generated/task.c
@@ -8,7 +8,6 @@
 #include "task.h"
 
 #include <mach/mach.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/thread.c
+++ b/Exploits/oobPCI/Sources/generated/thread.c
@@ -8,6 +8,7 @@
 #include "thread.h"
 
 #include <mach/mach.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/thread.c
+++ b/Exploits/oobPCI/Sources/generated/thread.c
@@ -6,6 +6,7 @@
 #define	__MIG_check__Reply__thread_act_subsystem__ 1
 
 #include "thread.h"
+
 #include <mach/mach.h>
 
 #ifdef __cplusplus

--- a/Exploits/oobPCI/Sources/generated/thread.c
+++ b/Exploits/oobPCI/Sources/generated/thread.c
@@ -6,8 +6,7 @@
 #define	__MIG_check__Reply__thread_act_subsystem__ 1
 
 #include "thread.h"
-
-/* TODO: #include <mach/mach.h> */
+#include <mach/mach.h>
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/thread.c
+++ b/Exploits/oobPCI/Sources/generated/thread.c
@@ -7,6 +7,7 @@
 
 #include "thread.h"
 #include <mach/mach.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */

--- a/Exploits/oobPCI/Sources/generated/thread.c
+++ b/Exploits/oobPCI/Sources/generated/thread.c
@@ -8,7 +8,6 @@
 #include "thread.h"
 
 #include <mach/mach.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* __cplusplus */


### PR DESCRIPTION
## Summary
- add `<mach/mach.h>` to generated device, mach_host, thread, and task stubs

## Testing
- `make` *(fails: xcrun not found)*
- `apt-get install -y xcrun` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689db0cd3bbc832d8e5197b5b70175e5